### PR TITLE
Reduce multiplications

### DIFF
--- a/benches/hash.rs
+++ b/benches/hash.rs
@@ -23,47 +23,47 @@ where
 
     let mut group = c.benchmark_group(format!("hash-{}", Arity::to_usize() * 32));
 
-    group.bench_with_input(
-        BenchmarkId::new("Sha2 256", "Generated scalars"),
-        &scalars,
-        |b, s| {
-            b.iter(|| {
-                let mut h = Sha256::new();
+    // group.bench_with_input(
+    //     BenchmarkId::new("Sha2 256", "Generated scalars"),
+    //     &scalars,
+    //     |b, s| {
+    //         b.iter(|| {
+    //             let mut h = Sha256::new();
 
-                std::iter::repeat(())
-                    .take(Arity::to_usize())
-                    .map(|_| s.choose(&mut OsRng).unwrap())
-                    .for_each(|scalar| {
-                        for val in scalar.into_repr().as_ref() {
-                            h.input(&val.to_le_bytes());
-                        }
-                    });
+    //             std::iter::repeat(())
+    //                 .take(Arity::to_usize())
+    //                 .map(|_| s.choose(&mut OsRng).unwrap())
+    //                 .for_each(|scalar| {
+    //                     for val in scalar.into_repr().as_ref() {
+    //                         h.input(&val.to_le_bytes());
+    //                     }
+    //                 });
 
-                h.result();
-            })
-        },
-    );
+    //             h.result();
+    //         })
+    //     },
+    // );
 
-    group.bench_with_input(
-        BenchmarkId::new("Sha2 512", "Generated scalars"),
-        &scalars,
-        |b, s| {
-            b.iter(|| {
-                let mut h = Sha512::new();
+    // group.bench_with_input(
+    //     BenchmarkId::new("Sha2 512", "Generated scalars"),
+    //     &scalars,
+    //     |b, s| {
+    //         b.iter(|| {
+    //             let mut h = Sha512::new();
 
-                std::iter::repeat(())
-                    .take(Arity::to_usize())
-                    .map(|_| s.choose(&mut OsRng).unwrap())
-                    .for_each(|scalar| {
-                        for val in scalar.into_repr().as_ref() {
-                            h.input(&val.to_le_bytes());
-                        }
-                    });
+    //             std::iter::repeat(())
+    //                 .take(Arity::to_usize())
+    //                 .map(|_| s.choose(&mut OsRng).unwrap())
+    //                 .for_each(|scalar| {
+    //                     for val in scalar.into_repr().as_ref() {
+    //                         h.input(&val.to_le_bytes());
+    //                     }
+    //                 });
 
-                h.result();
-            })
-        },
-    );
+    //             h.result();
+    //         })
+    //     },
+    // );
 
     group.bench_with_input(
         BenchmarkId::new("Poseidon hash", "Generated scalars"),
@@ -113,6 +113,7 @@ criterion_group! {
 
     config = Criterion::default();
 
-    targets = bench_hash::<typenum::U2>, bench_hash::<typenum::U4>, bench_hash::<typenum::U8>, bench_hash::<typenum::U11>
+//    targets = bench_hash::<typenum::U2>, bench_hash::<typenum::U4>, bench_hash::<typenum::U8>, bench_hash::<typenum::U11>
+    targets = bench_hash::<typenum::U23>
 }
 criterion_main!(hash);

--- a/benches/hash.rs
+++ b/benches/hash.rs
@@ -23,47 +23,47 @@ where
 
     let mut group = c.benchmark_group(format!("hash-{}", Arity::to_usize() * 32));
 
-    // group.bench_with_input(
-    //     BenchmarkId::new("Sha2 256", "Generated scalars"),
-    //     &scalars,
-    //     |b, s| {
-    //         b.iter(|| {
-    //             let mut h = Sha256::new();
+    group.bench_with_input(
+        BenchmarkId::new("Sha2 256", "Generated scalars"),
+        &scalars,
+        |b, s| {
+            b.iter(|| {
+                let mut h = Sha256::new();
 
-    //             std::iter::repeat(())
-    //                 .take(Arity::to_usize())
-    //                 .map(|_| s.choose(&mut OsRng).unwrap())
-    //                 .for_each(|scalar| {
-    //                     for val in scalar.into_repr().as_ref() {
-    //                         h.input(&val.to_le_bytes());
-    //                     }
-    //                 });
+                std::iter::repeat(())
+                    .take(Arity::to_usize())
+                    .map(|_| s.choose(&mut OsRng).unwrap())
+                    .for_each(|scalar| {
+                        for val in scalar.into_repr().as_ref() {
+                            h.input(&val.to_le_bytes());
+                        }
+                    });
 
-    //             h.result();
-    //         })
-    //     },
-    // );
+                h.result();
+            })
+        },
+    );
 
-    // group.bench_with_input(
-    //     BenchmarkId::new("Sha2 512", "Generated scalars"),
-    //     &scalars,
-    //     |b, s| {
-    //         b.iter(|| {
-    //             let mut h = Sha512::new();
+    group.bench_with_input(
+        BenchmarkId::new("Sha2 512", "Generated scalars"),
+        &scalars,
+        |b, s| {
+            b.iter(|| {
+                let mut h = Sha512::new();
 
-    //             std::iter::repeat(())
-    //                 .take(Arity::to_usize())
-    //                 .map(|_| s.choose(&mut OsRng).unwrap())
-    //                 .for_each(|scalar| {
-    //                     for val in scalar.into_repr().as_ref() {
-    //                         h.input(&val.to_le_bytes());
-    //                     }
-    //                 });
+                std::iter::repeat(())
+                    .take(Arity::to_usize())
+                    .map(|_| s.choose(&mut OsRng).unwrap())
+                    .for_each(|scalar| {
+                        for val in scalar.into_repr().as_ref() {
+                            h.input(&val.to_le_bytes());
+                        }
+                    });
 
-    //             h.result();
-    //         })
-    //     },
-    // );
+                h.result();
+            })
+        },
+    );
 
     group.bench_with_input(
         BenchmarkId::new("Poseidon hash", "Generated scalars"),
@@ -113,7 +113,6 @@ criterion_group! {
 
     config = Criterion::default();
 
-//    targets = bench_hash::<typenum::U2>, bench_hash::<typenum::U4>, bench_hash::<typenum::U8>, bench_hash::<typenum::U11>
-    targets = bench_hash::<typenum::U23>
+    targets = bench_hash::<typenum::U2>, bench_hash::<typenum::U4>, bench_hash::<typenum::U8>, bench_hash::<typenum::U11>
 }
 criterion_main!(hash);

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -115,7 +115,7 @@ where
         let mut result: Vec<AllocatedNum<E>> = Vec::with_capacity(self.constants.width());
 
         for j in 0..self.constants.width() {
-            let column = self.constants.mds_matrix[j].to_vec();
+            let column = self.constants.mds_matrices.m[j].to_vec();
             // TODO: This could be cached per round to save synthesis time.
             let constant_term = if add_round_keys {
                 let mut acc = E::Fr::zero();
@@ -223,7 +223,7 @@ where
     p.hash(cs)
 }
 
-pub fn create_poseidon_parameters<E, Arity>() -> PoseidonConstants<E, Arity>
+pub fn create_poseidon_parameters<'a, E, Arity>() -> PoseidonConstants<E, Arity>
 where
     E: Engine,
     Arity: typenum::Unsigned

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -478,6 +478,14 @@ mod tests {
     fn test_poseidon_hash() {
         let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
 
+        // TODO: add this exact calculation into the test.
+        // (It correctly yields the values in the cases below.)
+        // (defun constraints (arity rp &optional (rf 8))
+        //  (let* ((width (1+ arity))
+        //         (s-boxes (+ (* width rf) rp))
+        //         (s-box-constraints (* 3 s-boxes))
+        //         (mds-constraints (* width (+ rf rp))))
+        //   (+ s-box-constraints mds-constraints)))
         let cases = [(2, 426), (4, 608), (8, 972)];
 
         // TODO: test multiple arities.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,29 +93,6 @@ fn generate_mds<E: ScalarEngine>(t: usize) -> Vec<Vec<E::Fr>> {
     matrix
 }
 
-/// From the paper ():
-/// The round constants are generated using the Grain LFSR [23] in a self-shrinking
-/// mode:
-/// 1. Initialize the state with 80 bits b0, b1, . . . , b79, where
-/// (a) b0, b1 describe the field,
-/// (b) bi for 2 ≤ i ≤ 5 describe the S-Box,
-/// (c) bi for 6 ≤ i ≤ 17 are the binary representation of n,
-/// (d) bi for 18 ≤ i ≤ 29 are the binary representation of t,
-/// (e) bi for 30 ≤ i ≤ 39 are the binary representation of RF ,
-/// (f) bi for 40 ≤ i ≤ 49 are the binary representation of RP , and
-/// (g) bi for 50 ≤ i ≤ 79 are set to 1.
-/// 2. Update the bits using bi+80 = bi+62 ⊕ bi+51 ⊕ bi+38 ⊕ bi+23 ⊕ bi+13 ⊕ bi
-/// .
-/// 3. Discard the first 160 bits.
-/// 4. Evaluate bits in pairs: If the first bit is a 1, output the second bit. If it is a
-/// 0, discard the second bit.
-/// Using this method, the generation of round constants depends on the specific
-/// instance, and thus different round constants are used even if some of the chosen
-/// parameters (e.g., n and t) are the same.
-/// If a randomly sampled integer is not in Fp, we discard this value and take the
-/// next one. Note that cryptographically strong randomness is not needed for the
-/// round constants, and other methods can also be used.
-
 const SBOX: u8 = 1; // x^5
 const FIELD: u8 = 1; // Gf(p)
 const FIELD_SIZE: usize = 255; // n  Maybe Get this from Scalar.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,9 @@
 #![allow(dead_code)]
 
-use crate::matrix::is_invertible;
 pub use crate::poseidon::Poseidon;
 use crate::round_constants::generate_constants;
 pub use error::Error;
-use ff::{Field, PrimeField, ScalarEngine};
+use ff::{PrimeField, ScalarEngine};
 pub use paired::bls12_381::Fr as Scalar;
 use paired::bls12_381::FrRepr;
 
@@ -12,6 +11,7 @@ use paired::bls12_381::FrRepr;
 pub mod circuit;
 mod error;
 mod matrix;
+mod mds;
 /// Poseidon hash
 pub mod poseidon;
 mod round_constants;
@@ -43,54 +43,6 @@ pub fn scalar_from_u64<E: ScalarEngine>(i: u64) -> E::Fr {
 /// create field element from four u64
 pub fn scalar_from_u64s(parts: [u64; 4]) -> Scalar {
     Scalar::from_repr(FrRepr(parts)).unwrap()
-}
-
-fn generate_mds<E: ScalarEngine>(t: usize) -> Vec<Vec<E::Fr>> {
-    // Source: https://github.com/dusk-network/dusk-poseidon-merkle/commit/776c37734ea2e71bb608ce4bc58fdb5f208112a7#diff-2eee9b20fb23edcc0bf84b14167cbfdc
-    let mut matrix: Vec<Vec<E::Fr>> = Vec::with_capacity(t);
-    let mut xs: Vec<E::Fr> = Vec::with_capacity(t);
-    let mut ys: Vec<E::Fr> = Vec::with_capacity(t);
-
-    // Generate x and y values deterministically for the cauchy matrix
-    // where x[i] != y[i] to allow the values to be inverted
-    // and there are no duplicates in the x vector or y vector, so that the determinant is always non-zero
-    // [a b]
-    // [c d]
-    // det(M) = (ad - bc) ; if a == b and c == d => det(M) =0
-    // For an MDS matrix, every possible mxm submatrix, must have det(M) != 0
-    for i in 0..t {
-        let x = scalar_from_u64::<E>((i) as u64);
-        let y = scalar_from_u64::<E>((i + t) as u64);
-        xs.push(x);
-        ys.push(y);
-    }
-
-    // for i in 0..t {
-    //     let mut row: Vec<Scalar> = Vec::with_capacity(t);
-    //     for j in 0..t {
-    //         // Generate the entry at (i,j)
-    //         let entry = (xs[i] + ys[j]).invert();
-    //         row.insert(j, entry);
-    //     }
-    //     matrix.push(row);
-    // }
-    // Adapted from source above to use E::Fr.
-    for i in 0..t {
-        let mut row: Vec<E::Fr> = Vec::with_capacity(t);
-        for j in 0..t {
-            // Generate the entry at (i,j)
-            let mut tmp = xs[i];
-            tmp.add_assign(&ys[j]);
-            let entry = tmp.inverse().unwrap();
-            row.insert(j, entry);
-        }
-        matrix.push(row);
-    }
-
-    assert!(is_invertible::<E>(&matrix));
-    // To ensure correctness, we would check all sub-matrices for invertibility. Meanwhile, this is a simple sanity check.
-
-    matrix
 }
 
 const SBOX: u8 = 1; // x^5

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,15 +70,12 @@ fn quintic_s_box<E: ScalarEngine>(
     if let Some(x) = pre_add {
         l.add_assign(x);
     }
-    // dbg!("S-box input", &l);
     let c = *l;
     let mut tmp = l.clone();
     tmp.mul_assign(&c);
     tmp.mul_assign(&tmp.clone());
     l.mul_assign(&tmp);
-    // dbg!("S-box output", &l);
     if let Some(x) = post_add {
         l.add_assign(x);
-        //  dbg!("After S-box post-add", &l);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub fn round_numbers(arity: usize) -> (usize, usize) {
         2 | 3 => 55,
         4 | 5 | 6 | 7 => 56,
         8 | 9 | 10 | 11 | 12 => 57,
+        24 => 42, // Just for a comparative benchmark — don't use this.
         _ => panic!("unsupoorted arity"),
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 #![allow(dead_code)]
 
+use crate::matrix::is_invertible;
 pub use crate::poseidon::Poseidon;
 use crate::round_constants::generate_constants;
 pub use error::Error;
-use ff::ScalarEngine as Engine;
 use ff::{Field, PrimeField, ScalarEngine};
 pub use paired::bls12_381::Fr as Scalar;
 use paired::bls12_381::FrRepr;
@@ -11,6 +11,7 @@ use paired::bls12_381::FrRepr;
 /// Poseidon circuit
 pub mod circuit;
 mod error;
+mod matrix;
 /// Poseidon hash
 pub mod poseidon;
 mod round_constants;
@@ -44,7 +45,8 @@ pub fn scalar_from_u64s(parts: [u64; 4]) -> Scalar {
     Scalar::from_repr(FrRepr(parts)).unwrap()
 }
 
-fn generate_mds<E: Engine>(t: usize) -> Vec<Vec<E::Fr>> {
+fn generate_mds<E: ScalarEngine>(t: usize) -> Vec<Vec<E::Fr>> {
+    // Source: https://github.com/dusk-network/dusk-poseidon-merkle/commit/776c37734ea2e71bb608ce4bc58fdb5f208112a7#diff-2eee9b20fb23edcc0bf84b14167cbfdc
     let mut matrix: Vec<Vec<E::Fr>> = Vec::with_capacity(t);
     let mut xs: Vec<E::Fr> = Vec::with_capacity(t);
     let mut ys: Vec<E::Fr> = Vec::with_capacity(t);
@@ -63,6 +65,16 @@ fn generate_mds<E: Engine>(t: usize) -> Vec<Vec<E::Fr>> {
         ys.push(y);
     }
 
+    // for i in 0..t {
+    //     let mut row: Vec<Scalar> = Vec::with_capacity(t);
+    //     for j in 0..t {
+    //         // Generate the entry at (i,j)
+    //         let entry = (xs[i] + ys[j]).invert();
+    //         row.insert(j, entry);
+    //     }
+    //     matrix.push(row);
+    // }
+    // Adapted from source above to use E::Fr.
     for i in 0..t {
         let mut row: Vec<E::Fr> = Vec::with_capacity(t);
         for j in 0..t {
@@ -74,6 +86,9 @@ fn generate_mds<E: Engine>(t: usize) -> Vec<Vec<E::Fr>> {
         }
         matrix.push(row);
     }
+
+    assert!(is_invertible::<E>(&matrix));
+    // To ensure correctness, we would check all sub-matrices for invertibility. Meanwhile, this is a simple sanity check.
 
     matrix
 }

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -89,7 +89,7 @@ fn vec_mul<E: ScalarEngine>(a: &[Scalar<E>], b: &[Scalar<E>]) -> Scalar<E> {
         })
 }
 
-fn vec_add<E: ScalarEngine>(a: &[Scalar<E>], b: &[Scalar<E>]) -> Vec<Scalar<E>> {
+pub fn vec_add<E: ScalarEngine>(a: &[Scalar<E>], b: &[Scalar<E>]) -> Vec<Scalar<E>> {
     a.iter()
         .zip(b.iter())
         .map(|(a, b)| {

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -126,7 +126,10 @@ pub fn vec_sub<E: ScalarEngine>(a: &[Scalar<E>], b: &[Scalar<E>]) -> Vec<Scalar<
 }
 
 /// Left-multiply a vector by a square matrix of same size: MV where V is considered a column vector.
-pub fn apply_matrix<E: ScalarEngine>(m: &Matrix<Scalar<E>>, v: &[Scalar<E>]) -> Vec<Scalar<E>> {
+pub fn left_apply_matrix<E: ScalarEngine>(
+    m: &Matrix<Scalar<E>>,
+    v: &[Scalar<E>],
+) -> Vec<Scalar<E>> {
     assert!(is_square(m), "Only square matrix can be applied to vector.");
     assert_eq!(
         rows(m),
@@ -147,10 +150,7 @@ pub fn apply_matrix<E: ScalarEngine>(m: &Matrix<Scalar<E>>, v: &[Scalar<E>]) -> 
 }
 
 /// Right-multiply a vector by a square matrix  of same size: VM where V is considered a row vector.
-pub fn right_apply_matrix<E: ScalarEngine>(
-    m: &Matrix<Scalar<E>>,
-    v: &[Scalar<E>],
-) -> Vec<Scalar<E>> {
+pub fn apply_matrix<E: ScalarEngine>(m: &Matrix<Scalar<E>>, v: &[Scalar<E>]) -> Vec<Scalar<E>> {
     assert!(is_square(m), "Only square matrix can be applied to vector.");
     assert_eq!(
         rows(m),

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -100,6 +100,17 @@ pub fn vec_add<E: ScalarEngine>(a: &[Scalar<E>], b: &[Scalar<E>]) -> Vec<Scalar<
         .collect::<Vec<_>>()
 }
 
+pub fn vec_sub<E: ScalarEngine>(a: &[Scalar<E>], b: &[Scalar<E>]) -> Vec<Scalar<E>> {
+    a.iter()
+        .zip(b.iter())
+        .map(|(a, b)| {
+            let mut res = a.clone();
+            res.sub_assign(b);
+            res
+        })
+        .collect::<Vec<_>>()
+}
+
 /// Multiply a square matrix by a vector of same size: MV where V is considered a row vector.
 pub fn apply_matrix<E: ScalarEngine>(m: &Matrix<Scalar<E>>, v: &[Scalar<E>]) -> Vec<Scalar<E>> {
     assert!(is_square(m), "Only square matrix can be applied to vector.");

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -1,0 +1,380 @@
+use ff::{Field, ScalarEngine};
+
+/// Matrix functions here are, at least for now, quick and dirty — intended only to support precomputation of poseidon optimization.
+
+/// Matrix represented as a Vec of rows, so that m[i][j] represents the jth column of the ith row in Matrix, m.
+type Matrix<T> = Vec<Vec<T>>;
+type Scalar<E> = <E as ScalarEngine>::Fr;
+
+fn rows<T>(matrix: &Matrix<T>) -> usize {
+    matrix.len()
+}
+
+/// Panics if `matrix` is not actually a matrix. So only use any of these functions on well-formed data.
+/// Only use during constant calculation on matrices known to have been constructed correctly.
+fn columns<T>(matrix: &Matrix<T>) -> usize {
+    if matrix.len() > 0 {
+        let length = matrix[0].len();
+        for i in 1..rows(matrix) {
+            if matrix[i].len() != length {
+                panic!("not a matrix");
+            }
+        }
+        length
+    } else {
+        0
+    }
+}
+
+/// This is very inefficient as matrices grow. However, we only need it for preprocessing constants,
+/// and it is (for now) sufficient for the relatively small widths we need to support.
+/// TODO: Use a more efficient method.
+pub(crate) fn invert<E: ScalarEngine>(matrix: &Matrix<Scalar<E>>) -> Option<Matrix<Scalar<E>>> {
+    let cofactor_matrix = cofactor_matrix::<E>(matrix);
+    let determinant = determinant_with_cofactor_matrix::<E>(matrix, &cofactor_matrix);
+    let adjugate = transpose::<E>(&cofactor_matrix);
+
+    Some(scalar_mul::<E>(determinant.inverse()?, &adjugate))
+}
+
+pub(crate) fn is_invertible<E: ScalarEngine>(matrix: &Matrix<Scalar<E>>) -> bool {
+    is_square(matrix) && determinant::<E>(matrix) != Scalar::<E>::zero()
+}
+
+fn scalar_mul<E: ScalarEngine>(scalar: Scalar<E>, matrix: &Matrix<Scalar<E>>) -> Matrix<Scalar<E>> {
+    matrix
+        .iter()
+        .map(|row| {
+            row.iter()
+                .map(|val| {
+                    let mut prod = scalar.clone();
+                    prod.mul_assign(val);
+                    prod
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>()
+}
+
+fn mat_mul<E: ScalarEngine>(
+    a: &Matrix<Scalar<E>>,
+    b: &Matrix<Scalar<E>>,
+) -> Option<Matrix<Scalar<E>>> {
+    if rows(a) != columns(b) {
+        return None;
+    };
+
+    let b_t = transpose::<E>(b);
+
+    let mut res = Vec::with_capacity(rows(a));
+    for i in 0..rows(a) {
+        let mut row = Vec::with_capacity(columns(b));
+        for j in 0..columns(b) {
+            row.push(vec_mul::<E>(&a[i], &b_t[j]));
+        }
+        res.push(row);
+    }
+
+    Some(res)
+}
+
+fn vec_mul<E: ScalarEngine>(a: &Vec<Scalar<E>>, b: &Vec<Scalar<E>>) -> Scalar<E> {
+    a.iter()
+        .zip(b)
+        .fold(Scalar::<E>::zero(), |mut acc, (v1, v2)| {
+            let mut tmp = v1.clone();
+            tmp.mul_assign(&v2);
+            acc.add_assign(&tmp);
+            acc
+        })
+}
+
+fn transpose<E: ScalarEngine>(matrix: &Matrix<Scalar<E>>) -> Matrix<Scalar<E>> {
+    let size = rows(matrix);
+    let mut new = Vec::with_capacity(size);
+    for j in 0..size {
+        let mut row = Vec::with_capacity(size);
+        for i in 0..size {
+            row.push(matrix[i][j])
+        }
+        new.push(row);
+    }
+    new
+}
+
+fn is_identity<E: ScalarEngine>(matrix: &Matrix<Scalar<E>>) -> bool {
+    let one = Scalar::<E>::one();
+    let zero = Scalar::<E>::zero();
+
+    for i in 0..rows(matrix) {
+        for j in 0..columns(matrix) {
+            let kronecker = matrix[i][j] == if i == j { one } else { zero };
+            if !kronecker {
+                return false;
+            };
+        }
+    }
+    true
+}
+
+fn is_square<T>(matrix: &Matrix<T>) -> bool {
+    rows(matrix) == columns(matrix)
+}
+
+pub fn determinant<E: ScalarEngine>(matrix: &Matrix<Scalar<E>>) -> Scalar<E> {
+    let mut acc = Scalar::<E>::zero();
+
+    for j in 0..columns(matrix) {
+        let mut tmp = matrix[0][j];
+        let cofactor = cofactor::<E>(&matrix, 0, j);
+        tmp.mul_assign(&cofactor);
+        acc.add_assign(&tmp);
+    }
+    acc
+}
+
+fn determinant_with_cofactor_matrix<E: ScalarEngine>(
+    matrix: &Matrix<Scalar<E>>,
+    cofactor_matrix: &Matrix<Scalar<E>>,
+) -> Scalar<E> {
+    matrix[0]
+        .iter()
+        .zip(&cofactor_matrix[0])
+        .fold(Scalar::<E>::zero(), |mut acc, (a, b)| {
+            let mut tmp = a.clone();
+            tmp.mul_assign(&b);
+            acc.add_assign(&tmp);
+            acc
+        })
+}
+
+fn cofactor_matrix<E: ScalarEngine>(matrix: &Matrix<Scalar<E>>) -> Matrix<Scalar<E>> {
+    assert!(is_square(matrix));
+    let size = rows(matrix);
+    let mut m = Vec::with_capacity(size);
+    for i in 0..size {
+        let mut row = Vec::with_capacity(size);
+        for j in 0..size {
+            row.push(cofactor::<E>(matrix, i, j));
+        }
+        m.push(row);
+    }
+    m
+}
+
+fn cofactor<E: ScalarEngine>(matrix: &Matrix<Scalar<E>>, i: usize, j: usize) -> Scalar<E> {
+    let minor_det = if rows(matrix) == 1 {
+        Scalar::<E>::one()
+    } else {
+        let m = minor::<E>(matrix, i, j);
+        determinant::<E>(&m)
+    };
+
+    let mut acc = Scalar::<E>::zero();
+    if (i + j) % 2 == 0 {
+        acc.add_assign(&minor_det);
+    } else {
+        acc.sub_assign(&minor_det);
+    }
+    acc
+}
+
+fn minor<E: ScalarEngine>(matrix: &Matrix<Scalar<E>>, i: usize, j: usize) -> Matrix<Scalar<E>> {
+    assert!(is_square(matrix));
+    let size = rows(matrix);
+    assert!(size > 0);
+    let new_size = size - 1;
+    let mut new: Matrix<Scalar<E>> = Vec::with_capacity(new_size);
+
+    for ii in 0..size {
+        if ii != i {
+            let mut row = Vec::with_capacity(new_size);
+            for jj in 0..size {
+                if jj != j {
+                    row.push(matrix[ii][jj]);
+                }
+            }
+            new.push(row);
+        }
+    }
+    assert!(is_square(&new));
+    new
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scalar_from_u64;
+    use paired::bls12_381::Bls12;
+
+    #[test]
+    fn test_minor() {
+        let one = scalar_from_u64::<Bls12>(1);
+        let two = scalar_from_u64::<Bls12>(2);
+        let three = scalar_from_u64::<Bls12>(3);
+        let four = scalar_from_u64::<Bls12>(4);
+        let five = scalar_from_u64::<Bls12>(5);
+        let six = scalar_from_u64::<Bls12>(6);
+        let seven = scalar_from_u64::<Bls12>(7);
+        let eight = scalar_from_u64::<Bls12>(8);
+        let nine = scalar_from_u64::<Bls12>(9);
+
+        let m = vec![
+            vec![one, two, three],
+            vec![four, five, six],
+            vec![seven, eight, nine],
+        ];
+
+        let cases = [
+            (0, 0, vec![vec![five, six], vec![eight, nine]]),
+            (0, 1, vec![vec![four, six], vec![seven, nine]]),
+            (0, 2, vec![vec![four, five], vec![seven, eight]]),
+            (1, 0, vec![vec![two, three], vec![eight, nine]]),
+            (1, 1, vec![vec![one, three], vec![seven, nine]]),
+            (1, 2, vec![vec![one, two], vec![seven, eight]]),
+            (2, 0, vec![vec![two, three], vec![five, six]]),
+            (2, 1, vec![vec![one, three], vec![four, six]]),
+            (2, 2, vec![vec![one, two], vec![four, five]]),
+        ];
+        for (i, j, expected) in &cases {
+            let result = minor::<Bls12>(&m, *i, *j);
+
+            assert_eq!(*expected, result);
+        }
+        //        assert_eq!(, minor::<Bls12>(&vec![vec![one]], 0, 0));
+    }
+
+    #[test]
+    fn test_determinant() {
+        let one = scalar_from_u64::<Bls12>(1);
+        let two = scalar_from_u64::<Bls12>(2);
+        let three = scalar_from_u64::<Bls12>(3);
+        let four = scalar_from_u64::<Bls12>(4);
+        let five = scalar_from_u64::<Bls12>(5);
+        let six = scalar_from_u64::<Bls12>(6);
+        let seven = scalar_from_u64::<Bls12>(7);
+        let eight = scalar_from_u64::<Bls12>(8);
+
+        let m1 = vec![
+            vec![one, two, three],
+            vec![four, five, six],
+            vec![seven, eight, eight],
+        ];
+
+        let res1 = determinant::<Bls12>(&m1);
+        // + 1 * (40 - 48)
+        // - 2 * (32 - 42)
+        // + 3 * (32 - 35)
+
+        // + 1 * -8
+        // - 2 * -10
+        // + 3 * -3
+
+        // = -8 + 20 - 9 = 3
+        assert_eq!(three, res1);
+
+        let m2 = vec![vec![one, two], vec![three, eight]];
+        let res2 = determinant::<Bls12>(&m2);
+        // 1 * 8 - 2 * 3
+        // = 8 - 6 = 2
+
+        assert_eq!(two, res2);
+    }
+
+    #[test]
+    fn test_scalar_mul() {
+        let zero = scalar_from_u64::<Bls12>(0);
+        let one = scalar_from_u64::<Bls12>(1);
+        let two = scalar_from_u64::<Bls12>(2);
+        let three = scalar_from_u64::<Bls12>(3);
+        let four = scalar_from_u64::<Bls12>(4);
+        let six = scalar_from_u64::<Bls12>(6);
+
+        let m = vec![vec![zero, one], vec![two, three]];
+        let res = scalar_mul::<Bls12>(two, &m);
+
+        let expected = vec![vec![zero, two], vec![four, six]];
+
+        assert_eq!(expected, res);
+    }
+
+    #[test]
+    fn test_vec_mul() {
+        let one = scalar_from_u64::<Bls12>(1);
+        let two = scalar_from_u64::<Bls12>(2);
+        let three = scalar_from_u64::<Bls12>(3);
+        let four = scalar_from_u64::<Bls12>(4);
+        let five = scalar_from_u64::<Bls12>(5);
+        let six = scalar_from_u64::<Bls12>(6);
+
+        let a = vec![one, two, three];
+        let b = vec![four, five, six];
+        let res = vec_mul::<Bls12>(&a, &b);
+
+        let expected = scalar_from_u64::<Bls12>(32);
+
+        assert_eq!(expected, res);
+    }
+
+    #[test]
+    fn test_transpose() {
+        let one = scalar_from_u64::<Bls12>(1);
+        let two = scalar_from_u64::<Bls12>(2);
+        let three = scalar_from_u64::<Bls12>(3);
+        let four = scalar_from_u64::<Bls12>(4);
+        let five = scalar_from_u64::<Bls12>(5);
+        let six = scalar_from_u64::<Bls12>(6);
+        let seven = scalar_from_u64::<Bls12>(7);
+        let eight = scalar_from_u64::<Bls12>(8);
+        let nine = scalar_from_u64::<Bls12>(9);
+
+        let m = vec![
+            vec![one, two, three],
+            vec![four, five, six],
+            vec![seven, eight, nine],
+        ];
+
+        let expected = vec![
+            vec![one, four, seven],
+            vec![two, five, eight],
+            vec![three, six, nine],
+        ];
+
+        let res = transpose::<Bls12>(&m);
+        assert_eq!(expected, res);
+    }
+
+    #[test]
+    fn test_inverse() {
+        let one = scalar_from_u64::<Bls12>(1);
+        let two = scalar_from_u64::<Bls12>(2);
+        let three = scalar_from_u64::<Bls12>(3);
+        let four = scalar_from_u64::<Bls12>(4);
+        let five = scalar_from_u64::<Bls12>(5);
+        let six = scalar_from_u64::<Bls12>(6);
+        let seven = scalar_from_u64::<Bls12>(7);
+        let eight = scalar_from_u64::<Bls12>(8);
+        let nine = scalar_from_u64::<Bls12>(9);
+
+        let m1 = vec![
+            vec![one, two, three],
+            vec![four, five, six],
+            vec![seven, eight, nine],
+        ];
+
+        let m2 = vec![
+            vec![one, two, three],
+            vec![four, five, six],
+            vec![seven, eight, eight],
+        ];
+
+        assert!(!is_invertible::<Bls12>(&m1));
+        assert!(is_invertible::<Bls12>(&m2));
+
+        let inverse = invert::<Bls12>(&m2).unwrap();
+
+        let computed_identity = mat_mul::<Bls12>(&m2, &inverse).unwrap();
+
+        assert!(is_identity::<Bls12>(&computed_identity));
+    }
+}

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -78,7 +78,7 @@ fn mat_mul<E: ScalarEngine>(
     Some(res)
 }
 
-fn vec_mul<E: ScalarEngine>(a: &Vec<Scalar<E>>, b: &Vec<Scalar<E>>) -> Scalar<E> {
+fn vec_mul<E: ScalarEngine>(a: &[Scalar<E>], b: &[Scalar<E>]) -> Scalar<E> {
     a.iter()
         .zip(b)
         .fold(Scalar::<E>::zero(), |mut acc, (v1, v2)| {
@@ -89,7 +89,7 @@ fn vec_mul<E: ScalarEngine>(a: &Vec<Scalar<E>>, b: &Vec<Scalar<E>>) -> Scalar<E>
         })
 }
 
-fn vec_add<E: ScalarEngine>(a: &Vec<Scalar<E>>, b: &Vec<Scalar<E>>) -> Vec<Scalar<E>> {
+fn vec_add<E: ScalarEngine>(a: &[Scalar<E>], b: &[Scalar<E>]) -> Vec<Scalar<E>> {
     a.iter()
         .zip(b.iter())
         .map(|(a, b)| {
@@ -101,7 +101,7 @@ fn vec_add<E: ScalarEngine>(a: &Vec<Scalar<E>>, b: &Vec<Scalar<E>>) -> Vec<Scala
 }
 
 /// Multiply a square matrix by a vector of same size: MV where V is considered a row vector.
-pub fn apply_matrix<E: ScalarEngine>(m: &Matrix<Scalar<E>>, v: &Vec<Scalar<E>>) -> Vec<Scalar<E>> {
+pub fn apply_matrix<E: ScalarEngine>(m: &Matrix<Scalar<E>>, v: &[Scalar<E>]) -> Vec<Scalar<E>> {
     assert!(is_square(m), "Only square matrix can be applied to vector.");
     assert_eq!(
         rows(m),

--- a/src/mds.rs
+++ b/src/mds.rs
@@ -1,6 +1,6 @@
 use ff::{Field, ScalarEngine};
 
-use crate::matrix::{apply_matrix, invert, is_invertible, minor, Matrix, Scalar};
+use crate::matrix::{apply_matrix, invert, is_invertible, mat_mul, minor, Matrix, Scalar};
 use crate::scalar_from_u64;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -17,6 +17,10 @@ pub struct MDSMatrices<E: ScalarEngine> {
 
 pub fn create_mds_matrices<'a, E: ScalarEngine>(t: usize) -> MDSMatrices<E> {
     let m = generate_mds::<E>(t);
+    derive_mds_matrices(m)
+}
+
+pub fn derive_mds_matrices<'a, E: ScalarEngine>(m: Matrix<Scalar<E>>) -> MDSMatrices<E> {
     let m_inv = invert::<E>(&m).unwrap(); // m is MDS so invertible.
     let m_hat = minor::<E>(&m, 0, 0);
     let m_hat_inv = invert::<E>(&m_hat).unwrap(); // If this returns None, then `mds_matrix` was not correctly generated.
@@ -35,6 +39,21 @@ pub fn create_mds_matrices<'a, E: ScalarEngine>(t: usize) -> MDSMatrices<E> {
         m_prime_inv,
         m_double_prime_inv,
     }
+}
+
+pub fn factor_to_sparse_matrices<E: ScalarEngine>(
+    base_matrix: Matrix<Scalar<E>>,
+    n: usize,
+) -> Vec<Matrix<Scalar<E>>> {
+    let (last, mut all) = (0..n).fold((base_matrix.clone(), Vec::new()), |(curr, mut acc), _| {
+        let derived = derive_mds_matrices::<E>(curr);
+        acc.push(derived.m_double_prime);
+        let new = mat_mul::<E>(&base_matrix, &derived.m_prime).unwrap();
+        (new, acc)
+    });
+    all.push(last);
+    all.reverse();
+    all
 }
 
 fn generate_mds<E: ScalarEngine>(t: usize) -> Matrix<Scalar<E>> {
@@ -253,5 +272,51 @@ mod tests {
 
         dbg!(&m);
         //        assert_eq!(simple, alt);
+    }
+
+    #[test]
+    fn test_factor_to_sparse_matrices() {
+        test_factor_to_sparse_matrices_aux(3, 3);
+        test_factor_to_sparse_matrices_aux(4, 3);
+        test_factor_to_sparse_matrices_aux(5, 3);
+    }
+
+    fn test_factor_to_sparse_matrices_aux(width: usize, n: usize) {
+        let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
+
+        let m = generate_mds::<Bls12>(width);
+        let m2 = m.clone();
+
+        let sparse = factor_to_sparse_matrices::<Bls12>(m, n);
+        assert_eq!(n + 1, sparse.len());
+
+        let mut initial = Vec::with_capacity(width);
+        for _ in 0..width {
+            initial.push(Fr::random(&mut rng));
+        }
+
+        let mut round_keys = Vec::with_capacity(width);
+        for _ in 0..n {
+            round_keys.push(Fr::random(&mut rng));
+        }
+
+        let expected = std::iter::repeat(m2).take(n).zip(&round_keys).fold(
+            initial.clone(),
+            |mut acc, (m, rk)| {
+                apply_matrix::<Bls12>(&m, &acc);
+                quintic_s_box::<Bls12>(&mut acc[0], None, Some(&rk));
+                acc
+            },
+        );
+
+        let actual = sparse
+            .iter()
+            .zip(&round_keys)
+            .fold(initial.clone(), |mut acc, (m, rk)| {
+                apply_matrix::<Bls12>(&m, &acc);
+                quintic_s_box::<Bls12>(&mut acc[0], None, Some(&rk));
+                acc
+            });
+        assert_eq!(expected, actual);
     }
 }

--- a/src/mds.rs
+++ b/src/mds.rs
@@ -35,6 +35,12 @@ pub fn derive_mds_matrices<'a, E: ScalarEngine>(m: Matrix<Scalar<E>>) -> MDSMatr
     }
 }
 
+// - Having effectively moved the round-key additions into the S-boxes, refactor MDS matrices used for partial-round mix layer to use sparse matrices.
+// - This requires using a different (sparse) matrix at each partial round, rather than the same dense matrix at each.
+//   - The MDS matrix, M, for each such round, starting from the last, is factored into two components, such that M' x M'' = M.
+//   - M'' is sparse and replaces M for the round.
+//   - The previous layer's M is then replaced by M x M' = M*.
+//   - M* is likewise factored into M*' and M*'', and the process continues.
 pub fn factor_to_sparse_matrices<E: ScalarEngine>(
     base_matrix: Matrix<Scalar<E>>,
     n: usize,

--- a/src/mds.rs
+++ b/src/mds.rs
@@ -92,7 +92,9 @@ fn generate_mds<E: ScalarEngine>(t: usize) -> Matrix<Scalar<E>> {
         matrix.push(row);
     }
 
-    assert!(is_invertible::<E>(&matrix));
+    //assert!(is_invertible::<E>(&matrix));
+    // FIXME: Use performant method here.
+
     // To ensure correctness, we would check all sub-matrices for invertibility. Meanwhile, this is a simple sanity check.
     matrix
 }

--- a/src/mds.rs
+++ b/src/mds.rs
@@ -78,7 +78,6 @@ fn generate_mds<E: ScalarEngine>(t: usize) -> Matrix<Scalar<E>> {
 
     assert!(is_invertible::<E>(&matrix));
     // To ensure correctness, we would check all sub-matrices for invertibility. Meanwhile, this is a simple sanity check.
-
     matrix
 }
 
@@ -140,7 +139,7 @@ fn make_v_w<E: ScalarEngine>(m: &Matrix<Scalar<E>>) -> (Vec<Scalar<E>>, Vec<Scal
 mod tests {
     use super::*;
     use crate::*;
-    use matrix::right_apply_matrix;
+    use matrix::left_apply_matrix;
     use paired::bls12_381::{Bls12, Fr};
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
@@ -157,7 +156,7 @@ mod tests {
             m,
             m_inv,
             m_hat,
-            m_hat_inv,
+            m_hat_inv: _,
             m_prime,
             m_double_prime,
             m_prime_inv,
@@ -184,9 +183,6 @@ mod tests {
         assert!(matrix::is_identity::<Bls12>(
             &matrix::mat_mul::<Bls12>(&m_prime_inv, &m_prime).unwrap()
         ));
-
-        dbg!(m, m_prime, m_double_prime);
-        //        panic!();
     }
 
     #[test]
@@ -199,9 +195,9 @@ mod tests {
 
         let MDSMatrices {
             m,
-            m_inv,
-            m_hat,
-            m_hat_inv,
+            m_inv: _,
+            m_hat: _,
+            m_hat_inv: _,
             m_prime,
             m_double_prime,
             m_prime_inv,
@@ -225,18 +221,13 @@ mod tests {
         assert_eq!(zy[0], y[0]);
         assert_eq!(zx[1..], zy[1..]);
 
-        let ones = vec![Fr::one(); width];
-        let z_ones = apply_matrix::<Bls12>(&m_prime_inv, &ones);
-
-        let x_m1_m2 = right_apply_matrix::<Bls12>(
-            &m_double_prime,
-            &right_apply_matrix::<Bls12>(&m_prime, &x),
-        );
-        let xm = right_apply_matrix::<Bls12>(&m, &x);
+        let xm = apply_matrix::<Bls12>(&m, &x);
+        let x_m1_m2 = apply_matrix::<Bls12>(&m_double_prime, &apply_matrix::<Bls12>(&m_prime, &x));
         assert_eq!(xm, x_m1_m2);
 
-        let mx = apply_matrix::<Bls12>(&m, &x);
-        let m1_m2_x = apply_matrix::<Bls12>(&m_prime, &apply_matrix::<Bls12>(&m_double_prime, &x));
+        let mx = left_apply_matrix::<Bls12>(&m, &x);
+        let m1_m2_x =
+            left_apply_matrix::<Bls12>(&m_prime, &left_apply_matrix::<Bls12>(&m_double_prime, &x));
         assert_eq!(mx, m1_m2_x);
     }
 }

--- a/src/mds.rs
+++ b/src/mds.rs
@@ -1,0 +1,242 @@
+use ff::{Field, ScalarEngine};
+
+use crate::matrix::{apply_matrix, invert, is_invertible, minor, Matrix, Scalar};
+use crate::scalar_from_u64;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct MDSMatrices<E: ScalarEngine> {
+    pub m: Matrix<Scalar<E>>,
+    pub m_inv: Matrix<Scalar<E>>,
+    pub m_hat: Matrix<Scalar<E>>,
+    pub m_hat_inv: Matrix<Scalar<E>>,
+    pub m_prime: Matrix<Scalar<E>>,
+    pub m_double_prime: Matrix<Scalar<E>>,
+    pub m_prime_inv: Matrix<Scalar<E>>,
+}
+
+pub fn create_mds_matrices<'a, E: ScalarEngine>(t: usize) -> MDSMatrices<E> {
+    let m = generate_mds::<E>(t);
+    let m_inv = invert::<E>(&m).unwrap(); // m is MDS so invertible.
+    let m_hat = minor::<E>(&m, 0, 0);
+    let m_hat_inv = invert::<E>(&m_hat).unwrap(); // If this returns None, then `mds_matrix` was not correctly generated.
+    let m_prime = make_prime::<E>(&m);
+    let m_double_prime = make_double_prime::<E>(&m, &m_hat_inv);
+    let m_prime_inv = invert::<E>(&m_prime).unwrap();
+
+    MDSMatrices {
+        m,
+        m_inv,
+        m_hat,
+        m_hat_inv,
+        m_prime,
+        m_double_prime,
+        m_prime_inv,
+    }
+}
+
+fn generate_mds<E: ScalarEngine>(t: usize) -> Matrix<Scalar<E>> {
+    // Source: https://github.com/dusk-network/dusk-poseidon-merkle/commit/776c37734ea2e71bb608ce4bc58fdb5f208112a7#diff-2eee9b20fb23edcc0bf84b14167cbfdc
+    let mut matrix: Vec<Vec<E::Fr>> = Vec::with_capacity(t);
+    let mut xs: Vec<E::Fr> = Vec::with_capacity(t);
+    let mut ys: Vec<E::Fr> = Vec::with_capacity(t);
+
+    // Generate x and y values deterministically for the cauchy matrix
+    // where x[i] != y[i] to allow the values to be inverted
+    // and there are no duplicates in the x vector or y vector, so that the determinant is always non-zero
+    // [a b]
+    // [c d]
+    // det(M) = (ad - bc) ; if a == b and c == d => det(M) =0
+    // For an MDS matrix, every possible mxm submatrix, must have det(M) != 0
+    for i in 0..t {
+        let x = scalar_from_u64::<E>((i) as u64);
+        let y = scalar_from_u64::<E>((i + t) as u64);
+        xs.push(x);
+        ys.push(y);
+    }
+
+    // for i in 0..t {
+    //     let mut row: Vec<Scalar> = Vec::with_capacity(t);
+    //     for j in 0..t {
+    //         // Generate the entry at (i,j)
+    //         let entry = (xs[i] + ys[j]).invert();
+    //         row.insert(j, entry);
+    //     }
+    //     matrix.push(row);
+    // }
+    // Adapted from source above to use E::Fr.
+    for i in 0..t {
+        let mut row: Vec<E::Fr> = Vec::with_capacity(t);
+        for j in 0..t {
+            // Generate the entry at (i,j)
+            let mut tmp = xs[i];
+            tmp.add_assign(&ys[j]);
+            let entry = tmp.inverse().unwrap();
+            row.insert(j, entry);
+        }
+        matrix.push(row);
+    }
+
+    assert!(is_invertible::<E>(&matrix));
+    // To ensure correctness, we would check all sub-matrices for invertibility. Meanwhile, this is a simple sanity check.
+
+    matrix
+}
+
+fn make_prime<E: ScalarEngine>(m: &Matrix<Scalar<E>>) -> Matrix<Scalar<E>> {
+    m.iter()
+        .enumerate()
+        .map(|(i, row)| match i {
+            0 => {
+                let mut new_row = vec![Scalar::<E>::zero(); row.len()];
+                new_row[0] = Scalar::<E>::one();
+                new_row
+            }
+            _ => {
+                let mut new_row = vec![Scalar::<E>::zero(); row.len()];
+                new_row[1..].copy_from_slice(&row[1..]);
+                new_row
+            }
+        })
+        .collect()
+}
+
+fn make_double_prime<E: ScalarEngine>(
+    m: &Matrix<Scalar<E>>,
+    m_hat_inv: &Matrix<Scalar<E>>,
+) -> Matrix<Scalar<E>> {
+    let (v, w) = make_v_w::<E>(m);
+    let w_hat = apply_matrix::<E>(m_hat_inv, &w);
+
+    m.iter()
+        .enumerate()
+        .map(|(i, row)| match i {
+            0 => {
+                let mut new_row = Vec::with_capacity(row.len());
+                new_row.push(row[0]);
+                new_row.extend(&v);
+                new_row
+            }
+            _ => {
+                let mut new_row = vec![Scalar::<E>::zero(); row.len()];
+                new_row[0] = w_hat[i - 1];
+                new_row[i] = Scalar::<E>::one();
+                new_row
+            }
+        })
+        .collect()
+}
+
+fn make_v_w<E: ScalarEngine>(m: &Matrix<Scalar<E>>) -> (Vec<Scalar<E>>, Vec<Scalar<E>>) {
+    let v = m[0][1..].to_vec();
+    let mut w = Vec::new();
+    for i in 1..m.len() {
+        w.push(m[i][0]);
+    }
+
+    (v, w)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::*;
+    use matrix::right_apply_matrix;
+    use paired::bls12_381::{Bls12, Fr};
+    use rand::SeedableRng;
+    use rand_xorshift::XorShiftRng;
+
+    #[test]
+    fn test_mds_matrices_creation() {
+        for i in 2..5 {
+            test_mds_matrices_creation_aux(i);
+        }
+    }
+
+    fn test_mds_matrices_creation_aux(width: usize) {
+        let MDSMatrices {
+            m,
+            m_inv,
+            m_hat,
+            m_hat_inv,
+            m_prime,
+            m_double_prime,
+            m_prime_inv,
+        } = create_mds_matrices::<Bls12>(width);
+
+        for i in 0..m_hat.len() {
+            for j in 0..m_hat[i].len() {
+                assert_eq!(m[i + 1][j + 1], m_hat[i][j], "MDS minor has wrong value.");
+            }
+        }
+
+        // M^-1 x M = I
+        assert!(matrix::is_identity::<Bls12>(
+            &matrix::mat_mul::<Bls12>(&m_inv, &m).unwrap()
+        ));
+
+        // M' x M'' = I
+        assert_eq!(
+            m,
+            matrix::mat_mul::<Bls12>(&m_prime, &m_double_prime).unwrap()
+        );
+
+        //
+        assert!(matrix::is_identity::<Bls12>(
+            &matrix::mat_mul::<Bls12>(&m_prime_inv, &m_prime).unwrap()
+        ));
+
+        dbg!(m, m_prime, m_double_prime);
+        //        panic!();
+    }
+
+    #[test]
+    fn test_swapping() {
+        test_swapping_aux(3);
+    }
+
+    fn test_swapping_aux(width: usize) {
+        let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
+
+        let MDSMatrices {
+            m,
+            m_inv,
+            m_hat,
+            m_hat_inv,
+            m_prime,
+            m_double_prime,
+            m_prime_inv,
+        } = create_mds_matrices::<Bls12>(width);
+
+        let mut base = Vec::with_capacity(width);
+        for _ in 0..width {
+            base.push(Fr::random(&mut rng));
+        }
+
+        let mut x = base.clone();
+        x[0] = Fr::random(&mut rng);
+
+        let mut y = base.clone();
+        y[0] = Fr::random(&mut rng);
+
+        let zx = apply_matrix::<Bls12>(&m_prime_inv, &x);
+        let zy = apply_matrix::<Bls12>(&m_prime_inv, &y);
+
+        assert_eq!(zx[0], x[0]);
+        assert_eq!(zy[0], y[0]);
+        assert_eq!(zx[1..], zy[1..]);
+
+        let ones = vec![Fr::one(); width];
+        let z_ones = apply_matrix::<Bls12>(&m_prime_inv, &ones);
+
+        let x_m1_m2 = right_apply_matrix::<Bls12>(
+            &m_double_prime,
+            &right_apply_matrix::<Bls12>(&m_prime, &x),
+        );
+        let xm = right_apply_matrix::<Bls12>(&m, &x);
+        assert_eq!(xm, x_m1_m2);
+
+        let mx = apply_matrix::<Bls12>(&m, &x);
+        let m1_m2_x = apply_matrix::<Bls12>(&m_prime, &apply_matrix::<Bls12>(&m_double_prime, &x));
+        assert_eq!(mx, m1_m2_x);
+    }
+}

--- a/src/mds.rs
+++ b/src/mds.rs
@@ -70,16 +70,6 @@ fn generate_mds<E: ScalarEngine>(t: usize) -> Matrix<Scalar<E>> {
         ys.push(y);
     }
 
-    // for i in 0..t {
-    //     let mut row: Vec<Scalar> = Vec::with_capacity(t);
-    //     for j in 0..t {
-    //         // Generate the entry at (i,j)
-    //         let entry = (xs[i] + ys[j]).invert();
-    //         row.insert(j, entry);
-    //     }
-    //     matrix.push(row);
-    // }
-    // Adapted from source above to use E::Fr.
     for i in 0..t {
         let mut row: Vec<E::Fr> = Vec::with_capacity(t);
         for j in 0..t {
@@ -92,10 +82,9 @@ fn generate_mds<E: ScalarEngine>(t: usize) -> Matrix<Scalar<E>> {
         matrix.push(row);
     }
 
-    //assert!(is_invertible::<E>(&matrix));
-    // FIXME: Use performant method here.
-
     // To ensure correctness, we would check all sub-matrices for invertibility. Meanwhile, this is a simple sanity check.
+    assert!(is_invertible::<E>(&matrix));
+
     matrix
 }
 

--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -891,11 +891,11 @@ where
     fn product_mds(&mut self) {
         let mut result = GenericArray::<E::Fr, typenum::Add1<Arity>>::generate(|_| E::Fr::zero());
 
-        for (result, mds_row) in result.iter_mut().zip(self.constants.mds_matrices.m.iter()) {
-            for (mds, element) in mds_row.iter().zip(self.elements.iter()) {
-                let mut tmp = *mds;
-                tmp.mul_assign(element);
-                result.add_assign(&tmp);
+        for (j, val) in result.iter_mut().enumerate() {
+            for (i, row) in self.constants.mds_matrices.m.iter().enumerate() {
+                let mut tmp = row[j];
+                tmp.mul_assign(&self.elements[i]);
+                val.add_assign(&tmp);
             }
         }
 

--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -79,8 +79,6 @@ where
         let width = arity + 1;
 
         let mds_matrices = create_mds_matrices::<E>(width);
-        // let mds_matrix = generate_mds::<E>(width);
-        // let m_inv = matrix::invert::<E>(&mds_matrix).unwrap();
 
         let (full_rounds, partial_rounds) = round_numbers(arity);
         let half_full_rounds = full_rounds / 2;
@@ -618,7 +616,7 @@ mod tests {
     use super::*;
     use crate::*;
     use ff::Field;
-    use generic_array::typenum::{U2, U4, U8};
+    use generic_array::typenum::{U11, U2, U4, U8};
     use paired::bls12_381::Bls12;
 
     #[test]
@@ -670,6 +668,7 @@ mod tests {
         hash_values_aux::<U2>();
         hash_values_aux::<U4>();
         hash_values_aux::<U8>();
+        hash_values_aux::<U11>();
     }
 
     /// Simple test vectors to ensure results don't change unintentionally in development.
@@ -708,6 +707,13 @@ mod tests {
                 0xfb1eb8f641dd9dc3,
                 0xfd2a373272ebf604,
                 0x433c1e9e8de226e5,
+            ]),
+
+            11 => scalar_from_u64s([
+                0x3ea151bdba419d91,
+                0x861e5b917b9025aa,
+                0xfbd9089c1dda8c8a,
+                0x229f5e566b78ee21,
             ]),
             _ => {
                 dbg!(digest);

--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -618,7 +618,7 @@ mod tests {
     use super::*;
     use crate::*;
     use ff::Field;
-    use generic_array::typenum::U2;
+    use generic_array::typenum::{U2, U4, U8};
     use paired::bls12_381::Bls12;
 
     #[test]
@@ -668,6 +668,8 @@ mod tests {
     #[test]
     fn hash_values() {
         hash_values_aux::<U2>();
+        hash_values_aux::<U4>();
+        hash_values_aux::<U8>();
     }
 
     /// Simple test vectors to ensure results don't change unintentionally in development.

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -238,33 +238,15 @@ fn preprocess_matrices<E: ScalarEngine>(
     let round_acc = (0..partial_preprocessed)
         .map(|i| round_keys(final_round - i - 1))
         .fold(final_round_key, |acc, previous_round_keys| {
-            //let mut inverted = apply_matrix::<E>(inverse_matrix, &acc);
             let mut inverted = apply_matrix::<E>(m_double_prime_inv, &acc);
 
             partial_keys.push(inverted[0]);
-            dbg!("partial_key", &inverted[0]);
             inverted = apply_matrix::<E>(m_prime_inv, &inverted);
             inverted[0] = E::Fr::zero();
 
             let res1 = vec_add::<E>(&previous_round_keys, &inverted);
-            //res1
             apply_matrix::<E>(m_prime, &res1)
         });
-
-    // let _round_acc = (0..partial_preprocessed)
-    //     .map(|i| round_keys(final_round - i - 1))
-    //     .fold(final_round_key, |acc, previous_round_keys| {
-    //         let mut inverted = apply_matrix::<E>(inverse_matrix, &acc);
-    //         //let mut inverted = apply_matrix::<E>(m_double_prime_inv, &acc);
-
-    //         partial_keys.push(inverted[0]);
-    //         //            inverted = apply_matrix::<E>(m_prime_inv, &inverted);
-    //         inverted[0] = E::Fr::zero();
-
-    //         let res1 = vec_add::<E>(&previous_round_keys, &inverted);
-    //         res1
-    //         //apply_matrix::<E>(m_prime, &res1)
-    //     });
 
     // Everything in here is dev-driven testing.
     // Dev test case only checks one deep.

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -1,0 +1,380 @@
+use crate::matrix::{apply_matrix, vec_add};
+use crate::mds::MDSMatrices;
+use crate::quintic_s_box;
+use ff::{Field, ScalarEngine};
+
+pub(crate) fn preprocess_round_constants<E: ScalarEngine>(
+    width: usize,
+    full_rounds: usize,
+    partial_rounds: usize,
+    round_constants: &Vec<E::Fr>,
+    mds_matrices: &MDSMatrices<E>,
+    partial_preprocessed: usize,
+) -> Vec<E::Fr> {
+    let mds_matrix = &mds_matrices.m;
+    let inverse_matrix = &mds_matrices.m_inv;
+
+    let mut res = Vec::new();
+
+    let round_keys = |r: usize| &round_constants[r * width..(r + 1) * width];
+
+    let half_full_rounds = full_rounds / 2; // Not half-full rounds; half full-rounds.
+
+    // First round constants are unchanged.
+    res.extend(round_keys(0));
+
+    let unpreprocessed = partial_rounds - partial_preprocessed;
+
+    // Post S-box adds for the first set of full rounds should be 'inverted' from next round.
+    // The final round is skipped when fully preprocessing because that value must be obtained from the result of preprocesing the partial rounds.
+    let end = if unpreprocessed > 0 {
+        half_full_rounds
+    } else {
+        half_full_rounds - 1
+    };
+    for i in 0..end {
+        let next_round = round_keys(i + 1); // First round was added before any S-boxes.
+        let inverted = apply_matrix::<E>(inverse_matrix, next_round);
+        res.extend(inverted);
+    }
+
+    // The plan:
+    // - Work backwards from last row in this group
+    // - Invert the row.
+    // - Save first constant (corresponding to the one S-box performed).
+    // - Add inverted result to previous row.
+    // - Repeat until all partial round key rows have been consumed.
+    // - Extend the preprocessed result by the final resultant row.
+    // - Move the accumulated list of single round keys to the preprocessed result.
+    //   - (Last produced should be first applied, so either pop until empty, or reverse and extend, etc.
+
+    // `partial_keys` will accumulate the single post-S-box constant for each partial-round, in reverse order.
+    let mut partial_keys: Vec<E::Fr> = Vec::new();
+
+    let final_round = half_full_rounds + partial_rounds;
+    let final_round_key = round_keys(final_round).to_vec();
+
+    // `round_acc` holds the accumulated result of inverting and adding subsequent round constants (in reverse).
+    let round_acc = (0..partial_preprocessed)
+        .map(|i| round_keys(final_round - i - 1))
+        .fold(final_round_key, |acc, previous_round_keys| {
+            let mut inverted = apply_matrix::<E>(inverse_matrix, &acc);
+
+            partial_keys.push(inverted[0]);
+            inverted[0] = E::Fr::zero();
+
+            vec_add::<E>(&previous_round_keys, &inverted)
+        });
+
+    // Everything in here is dev-driven testing.
+    // Dev test case only checks one deep.
+    if partial_preprocessed == 1 {
+        // Check assumptions about how the fold calculating round_acc  manifested.
+
+        // The last round containing unpreprocessed constants which should be compressed.
+        let terminal_constants_round = half_full_rounds + partial_rounds;
+
+        // Constants from the last round (of two) which should be compressed.
+        // T
+        let terminal_round_keys = round_keys(terminal_constants_round);
+
+        // Constants from the first round (of two) which should be compressed.
+        // I
+        let initial_round_keys = round_keys(terminal_constants_round - 1);
+
+        // M^-1(T)
+        let mut inv = apply_matrix::<E>(inverse_matrix, terminal_round_keys);
+
+        // M^-1(T)[0]
+        let pk = inv[0];
+
+        // M^-1(T) - pk (kinda)
+        inv[0] = E::Fr::zero();
+
+        // (M^-1(T) - pk) - I
+        let result_key = vec_add::<E>(&initial_round_keys, &inv);
+
+        dbg!(&result_key, &round_acc);
+
+        assert_eq!(&result_key, &round_acc, "Acc assumption failed.");
+        assert_eq!(pk, partial_keys[0], "Partial-key assumption failed.");
+        assert_eq!(
+            1,
+            partial_keys.len(),
+            "Partial-keys length assumption failed."
+        );
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // Shared between branches, arbitrary initial state representing the output of a previous round's S-Box layer.
+        // X
+        let initial_state = vec![E::Fr::one(); width];
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // Compute one step with the given (unpreprocessed) constants.
+
+        // ARK
+        // I + X
+        let mut q_state = vec_add::<E>(initial_round_keys, &initial_state);
+
+        // S-Box (partial layer)
+        // S((I + X)[0]) = S(I[0] + X[0])
+        quintic_s_box::<E>(&mut q_state[0], None, None);
+
+        // Mix with mds_matrix
+        let mixed = apply_matrix::<E>(mds_matrix, &q_state);
+
+        // Ark
+        let plain_result = vec_add::<E>(terminal_round_keys, &mixed);
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // Compute the same step using the preprocessed constants.
+        // M'(initial_state) + (inverted_id - initial_state) = inverted_id
+        //let initial_state1 = apply_matrix::<E>(&m_prime, &initial_state);
+        let mut p_state = vec_add::<E>(&result_key, &initial_state);
+
+        // In order for the S-box result to be correct, it must have the same input as in the plain path.
+        // That means its input (the first component of the state) must have been constructed by
+        // adding the same single round constant in that position.
+        // NOTE: this asssertion uncovered a bug which was causing failure.
+        assert_eq!(
+            &result_key[0], &initial_round_keys[0],
+            "S-box inputs did not match."
+        );
+
+        quintic_s_box::<E>(&mut p_state[0], None, Some(&pk));
+        dbg!("preprocessed S-box post-add", &pk);
+
+        let preprocessed_result = apply_matrix::<E>(&mds_matrix, &p_state);
+
+        assert_eq!(
+            plain_result, preprocessed_result,
+            "Single preprocessing step couldn't be verified."
+        );
+    }
+
+    for i in 1..unpreprocessed {
+        res.extend(round_keys(half_full_rounds + i));
+    }
+    res.extend(apply_matrix::<E>(inverse_matrix, &round_acc));
+    //res.extend(&round_acc);
+    dbg!("ROUND ACC", &round_acc);
+
+    dbg!(&partial_keys.len());
+
+    while let Some(x) = partial_keys.pop() {
+        res.push(x)
+    }
+
+    // Post S-box adds for the first set of full rounds should be 'inverted' from next round.
+    for i in 1..(half_full_rounds) {
+        let start = half_full_rounds + partial_rounds;
+        let next_round = round_keys(i + start);
+        let inverted = apply_matrix::<E>(inverse_matrix, next_round);
+        res.extend(inverted);
+    }
+
+    dbg!(&res.len(), &res);
+    res
+}
+
+// Legacy WIP: This will be used to preprocess the matrices.
+fn preprocess_matrices<E: ScalarEngine>(
+    width: usize,
+    full_rounds: usize,
+    partial_rounds: usize,
+    round_constants: &Vec<E::Fr>,
+    mds_matrices: &MDSMatrices<E>,
+    partial_preprocessed: usize,
+) -> Vec<E::Fr> {
+    let mds_matrix = &mds_matrices.m;
+    let inverse_matrix = &mds_matrices.m_inv;
+
+    let mut res = Vec::new();
+
+    let round_keys = |r: usize| &round_constants[r * width..(r + 1) * width];
+
+    let half_full_rounds = full_rounds / 2; // Not half-full rounds; half full-rounds.
+
+    // First round constants are unchanged.
+    res.extend(round_keys(0));
+
+    let unpreprocessed = partial_rounds - partial_preprocessed;
+
+    // Post S-box adds for the first set of full rounds should be 'inverted' from next round.
+    // The final round is skipped when fully preprocessing because that value must be obtained from the result of preprocesing the partial rounds.
+    let end = if unpreprocessed > 0 {
+        half_full_rounds
+    } else {
+        half_full_rounds - 1
+    };
+    for i in 0..end {
+        let next_round = round_keys(i + 1); // First round was added before any S-boxes.
+        let inverted = apply_matrix::<E>(inverse_matrix, next_round);
+        res.extend(inverted);
+    }
+
+    // The plan:
+    // - Work backwards from last row in this group
+    // - Invert the row.
+    // - Save first constant (corresponding to the one S-box performed).
+    // - Add inverted result to previous row.
+    // - Repeat until all partial round key rows have been consumed.
+    // - Extend the preprocessed result by the final resultant row.
+    // - Move the accumulated list of single round keys to the preprocessed result.
+    //   - (Last produced should be first applied, so either pop until empty, or reverse and extend, etc.
+
+    // `partial_keys` will accumulate the single post-S-box constant for each partial-round, in reverse order.
+    let mut partial_keys: Vec<E::Fr> = Vec::new();
+
+    let final_round = half_full_rounds + partial_rounds;
+    let final_round_key = round_keys(final_round).to_vec();
+
+    let m_prime = &mds_matrices.m_prime;
+    let m_prime_inv = &mds_matrices.m_prime_inv;
+    let m_double_prime = &mds_matrices.m_double_prime;
+    let m_double_prime_inv = &mds_matrices.m_double_prime_inv;
+
+    // `round_acc` holds the accumulated result of inverting and adding subsequent round constants (in reverse).
+    let round_acc = (0..partial_preprocessed)
+        .map(|i| round_keys(final_round - i - 1))
+        .fold(final_round_key, |acc, previous_round_keys| {
+            //let mut inverted = apply_matrix::<E>(inverse_matrix, &acc);
+            let mut inverted = apply_matrix::<E>(m_double_prime_inv, &acc);
+
+            partial_keys.push(inverted[0]);
+            dbg!("partial_key", &inverted[0]);
+            inverted = apply_matrix::<E>(m_prime_inv, &inverted);
+            inverted[0] = E::Fr::zero();
+
+            let res1 = vec_add::<E>(&previous_round_keys, &inverted);
+            //res1
+            apply_matrix::<E>(m_prime, &res1)
+        });
+
+    // let _round_acc = (0..partial_preprocessed)
+    //     .map(|i| round_keys(final_round - i - 1))
+    //     .fold(final_round_key, |acc, previous_round_keys| {
+    //         let mut inverted = apply_matrix::<E>(inverse_matrix, &acc);
+    //         //let mut inverted = apply_matrix::<E>(m_double_prime_inv, &acc);
+
+    //         partial_keys.push(inverted[0]);
+    //         //            inverted = apply_matrix::<E>(m_prime_inv, &inverted);
+    //         inverted[0] = E::Fr::zero();
+
+    //         let res1 = vec_add::<E>(&previous_round_keys, &inverted);
+    //         res1
+    //         //apply_matrix::<E>(m_prime, &res1)
+    //     });
+
+    // Everything in here is dev-driven testing.
+    // Dev test case only checks one deep.
+    if partial_preprocessed == 1 {
+        // Check assumptions about how the fold calculating round_acc  manifested.
+
+        // The last round containing unpreprocessed constants which should be compressed.
+        let terminal_constants_round = half_full_rounds + partial_rounds;
+
+        // Constants from the last round (of two) which should be compressed.
+        // T
+        let terminal_round_keys = round_keys(terminal_constants_round);
+
+        // Constants from the first round (of two) which should be compressed.
+        // I
+        let initial_round_keys = round_keys(terminal_constants_round - 1);
+
+        // M^-1(T)
+        let mut inv = apply_matrix::<E>(m_double_prime_inv, terminal_round_keys);
+
+        // M^-1(T)[0]
+        let pk = inv[0];
+
+        inv = apply_matrix::<E>(m_prime_inv, &inv);
+        // M^-1(T) - pk (kinda)
+        inv[0] = E::Fr::zero();
+
+        // (M^-1(T) - pk) - I
+        let result_key1 = vec_add::<E>(&initial_round_keys, &inv);
+        let result_key = apply_matrix::<E>(&m_prime, &result_key1);
+
+        dbg!(&result_key, &round_acc);
+
+        assert_eq!(&result_key, &round_acc, "Acc assumption failed.");
+        assert_eq!(pk, partial_keys[0], "Partial-key assumption failed.");
+        assert_eq!(
+            1,
+            partial_keys.len(),
+            "Partial-keys length assumption failed."
+        );
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // Shared between branches, arbitrary initial state representing the output of a previous round's S-Box layer.
+        // X
+        let initial_state = vec![E::Fr::one(); width];
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // Compute one step with the given (unpreprocessed) constants.
+
+        // ARK
+        // I + X
+        let mut q_state = vec_add::<E>(initial_round_keys, &initial_state);
+
+        // S-Box (partial layer)
+        // S((I + X)[0]) = S(I[0] + X[0])
+        quintic_s_box::<E>(&mut q_state[0], None, None);
+
+        // Mix with mds_matrix
+        let mixed = apply_matrix::<E>(mds_matrix, &q_state);
+
+        // Ark
+        let plain_result = vec_add::<E>(terminal_round_keys, &mixed);
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // Compute the same step using the preprocessed constants.
+        // M'(initial_state) + (inverted_id - initial_state) = inverted_id
+        let initial_state1 = apply_matrix::<E>(&m_prime, &initial_state);
+        let mut p_state = vec_add::<E>(&result_key, &initial_state1);
+
+        // In order for the S-box result to be correct, it must have the same input as in the plain path.
+        // That means its input (the first component of the state) must have been constructed by
+        // adding the same single round constant in that position.
+        // NOTE: this asssertion uncovered a bug which was causing failure.
+        assert_eq!(
+            &result_key[0], &initial_round_keys[0],
+            "S-box inputs did not match."
+        );
+
+        quintic_s_box::<E>(&mut p_state[0], None, Some(&pk));
+        dbg!("preprocessed S-box post-add", &pk);
+
+        let preprocessed_result = apply_matrix::<E>(&m_double_prime, &p_state);
+
+        assert_eq!(
+            plain_result, preprocessed_result,
+            "Single preprocessing step couldn't be verified."
+        );
+    }
+
+    for i in 1..unpreprocessed {
+        res.extend(round_keys(half_full_rounds + i));
+    }
+    //    res.extend(matrix::apply_matrix::<E>(inverse_matrix, &round_acc));
+    res.extend(&round_acc);
+    dbg!("ROUND ACC", &round_acc);
+
+    dbg!(&partial_keys.len());
+
+    while let Some(x) = partial_keys.pop() {
+        res.push(x)
+    }
+
+    // Post S-box adds for the first set of full rounds should be 'inverted' from next round.
+    for i in 1..(half_full_rounds) {
+        let start = half_full_rounds + partial_rounds;
+        let next_round = round_keys(i + start);
+        let inverted = apply_matrix::<E>(inverse_matrix, next_round);
+        res.extend(inverted);
+    }
+
+    dbg!(&res.len(), &res);
+    res
+}

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -3,7 +3,7 @@ use crate::mds::MDSMatrices;
 use crate::quintic_s_box;
 use ff::{Field, ScalarEngine};
 
-pub(crate) fn preprocess_round_constants<E: ScalarEngine>(
+pub(crate) fn compress_round_constants<E: ScalarEngine>(
     width: usize,
     full_rounds: usize,
     partial_rounds: usize,

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -3,6 +3,8 @@ use crate::mds::MDSMatrices;
 use crate::quintic_s_box;
 use ff::{Field, ScalarEngine};
 
+// - Compress constants by pushing them back through linear layers and through the identity components of partial layers.
+// - As a result, constants need only be added after each S-box.
 pub(crate) fn compress_round_constants<E: ScalarEngine>(
     width: usize,
     full_rounds: usize,

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -94,8 +94,6 @@ pub(crate) fn compress_round_constants<E: ScalarEngine>(
         // (M^-1(T) - pk) - I
         let result_key = vec_add::<E>(&initial_round_keys, &inv);
 
-        dbg!(&result_key, &round_acc);
-
         assert_eq!(&result_key, &round_acc, "Acc assumption failed.");
         assert_eq!(pk, partial_keys[0], "Partial-key assumption failed.");
         assert_eq!(
@@ -142,7 +140,6 @@ pub(crate) fn compress_round_constants<E: ScalarEngine>(
         );
 
         quintic_s_box::<E>(&mut p_state[0], None, Some(&pk));
-        dbg!("preprocessed S-box post-add", &pk);
 
         let preprocessed_result = apply_matrix::<E>(&mds_matrix, &p_state);
 
@@ -156,10 +153,6 @@ pub(crate) fn compress_round_constants<E: ScalarEngine>(
         res.extend(round_keys(half_full_rounds + i));
     }
     res.extend(apply_matrix::<E>(inverse_matrix, &round_acc));
-    //res.extend(&round_acc);
-    dbg!("ROUND ACC", &round_acc);
-
-    dbg!(&partial_keys.len());
 
     while let Some(x) = partial_keys.pop() {
         res.push(x)
@@ -173,190 +166,5 @@ pub(crate) fn compress_round_constants<E: ScalarEngine>(
         res.extend(inverted);
     }
 
-    dbg!(&res.len(), &res);
-    res
-}
-
-// Legacy WIP: This will be used to preprocess the matrices.
-fn preprocess_matrices<E: ScalarEngine>(
-    width: usize,
-    full_rounds: usize,
-    partial_rounds: usize,
-    round_constants: &Vec<E::Fr>,
-    mds_matrices: &MDSMatrices<E>,
-    partial_preprocessed: usize,
-) -> Vec<E::Fr> {
-    let mds_matrix = &mds_matrices.m;
-    let inverse_matrix = &mds_matrices.m_inv;
-
-    let mut res = Vec::new();
-
-    let round_keys = |r: usize| &round_constants[r * width..(r + 1) * width];
-
-    let half_full_rounds = full_rounds / 2; // Not half-full rounds; half full-rounds.
-
-    // First round constants are unchanged.
-    res.extend(round_keys(0));
-
-    let unpreprocessed = partial_rounds - partial_preprocessed;
-
-    // Post S-box adds for the first set of full rounds should be 'inverted' from next round.
-    // The final round is skipped when fully preprocessing because that value must be obtained from the result of preprocesing the partial rounds.
-    let end = if unpreprocessed > 0 {
-        half_full_rounds
-    } else {
-        half_full_rounds - 1
-    };
-    for i in 0..end {
-        let next_round = round_keys(i + 1); // First round was added before any S-boxes.
-        let inverted = apply_matrix::<E>(inverse_matrix, next_round);
-        res.extend(inverted);
-    }
-
-    // The plan:
-    // - Work backwards from last row in this group
-    // - Invert the row.
-    // - Save first constant (corresponding to the one S-box performed).
-    // - Add inverted result to previous row.
-    // - Repeat until all partial round key rows have been consumed.
-    // - Extend the preprocessed result by the final resultant row.
-    // - Move the accumulated list of single round keys to the preprocessed result.
-    //   - (Last produced should be first applied, so either pop until empty, or reverse and extend, etc.
-
-    // `partial_keys` will accumulate the single post-S-box constant for each partial-round, in reverse order.
-    let mut partial_keys: Vec<E::Fr> = Vec::new();
-
-    let final_round = half_full_rounds + partial_rounds;
-    let final_round_key = round_keys(final_round).to_vec();
-
-    let m_prime = &mds_matrices.m_prime;
-    let m_prime_inv = &mds_matrices.m_prime_inv;
-    let m_double_prime = &mds_matrices.m_double_prime;
-    let m_double_prime_inv = &mds_matrices.m_double_prime_inv;
-
-    // `round_acc` holds the accumulated result of inverting and adding subsequent round constants (in reverse).
-    let round_acc = (0..partial_preprocessed)
-        .map(|i| round_keys(final_round - i - 1))
-        .fold(final_round_key, |acc, previous_round_keys| {
-            let mut inverted = apply_matrix::<E>(m_double_prime_inv, &acc);
-
-            partial_keys.push(inverted[0]);
-            inverted = apply_matrix::<E>(m_prime_inv, &inverted);
-            inverted[0] = E::Fr::zero();
-
-            let res1 = vec_add::<E>(&previous_round_keys, &inverted);
-            apply_matrix::<E>(m_prime, &res1)
-        });
-
-    // Everything in here is dev-driven testing.
-    // Dev test case only checks one deep.
-    if partial_preprocessed == 1 {
-        // Check assumptions about how the fold calculating round_acc  manifested.
-
-        // The last round containing unpreprocessed constants which should be compressed.
-        let terminal_constants_round = half_full_rounds + partial_rounds;
-
-        // Constants from the last round (of two) which should be compressed.
-        // T
-        let terminal_round_keys = round_keys(terminal_constants_round);
-
-        // Constants from the first round (of two) which should be compressed.
-        // I
-        let initial_round_keys = round_keys(terminal_constants_round - 1);
-
-        // M^-1(T)
-        let mut inv = apply_matrix::<E>(m_double_prime_inv, terminal_round_keys);
-
-        // M^-1(T)[0]
-        let pk = inv[0];
-
-        inv = apply_matrix::<E>(m_prime_inv, &inv);
-        // M^-1(T) - pk (kinda)
-        inv[0] = E::Fr::zero();
-
-        // (M^-1(T) - pk) - I
-        let result_key1 = vec_add::<E>(&initial_round_keys, &inv);
-        let result_key = apply_matrix::<E>(&m_prime, &result_key1);
-
-        dbg!(&result_key, &round_acc);
-
-        assert_eq!(&result_key, &round_acc, "Acc assumption failed.");
-        assert_eq!(pk, partial_keys[0], "Partial-key assumption failed.");
-        assert_eq!(
-            1,
-            partial_keys.len(),
-            "Partial-keys length assumption failed."
-        );
-
-        ////////////////////////////////////////////////////////////////////////////////
-        // Shared between branches, arbitrary initial state representing the output of a previous round's S-Box layer.
-        // X
-        let initial_state = vec![E::Fr::one(); width];
-
-        ////////////////////////////////////////////////////////////////////////////////
-        // Compute one step with the given (unpreprocessed) constants.
-
-        // ARK
-        // I + X
-        let mut q_state = vec_add::<E>(initial_round_keys, &initial_state);
-
-        // S-Box (partial layer)
-        // S((I + X)[0]) = S(I[0] + X[0])
-        quintic_s_box::<E>(&mut q_state[0], None, None);
-
-        // Mix with mds_matrix
-        let mixed = apply_matrix::<E>(mds_matrix, &q_state);
-
-        // Ark
-        let plain_result = vec_add::<E>(terminal_round_keys, &mixed);
-
-        ////////////////////////////////////////////////////////////////////////////////
-        // Compute the same step using the preprocessed constants.
-        // M'(initial_state) + (inverted_id - initial_state) = inverted_id
-        let initial_state1 = apply_matrix::<E>(&m_prime, &initial_state);
-        let mut p_state = vec_add::<E>(&result_key, &initial_state1);
-
-        // In order for the S-box result to be correct, it must have the same input as in the plain path.
-        // That means its input (the first component of the state) must have been constructed by
-        // adding the same single round constant in that position.
-        // NOTE: this asssertion uncovered a bug which was causing failure.
-        assert_eq!(
-            &result_key[0], &initial_round_keys[0],
-            "S-box inputs did not match."
-        );
-
-        quintic_s_box::<E>(&mut p_state[0], None, Some(&pk));
-        dbg!("preprocessed S-box post-add", &pk);
-
-        let preprocessed_result = apply_matrix::<E>(&m_double_prime, &p_state);
-
-        assert_eq!(
-            plain_result, preprocessed_result,
-            "Single preprocessing step couldn't be verified."
-        );
-    }
-
-    for i in 1..unpreprocessed {
-        res.extend(round_keys(half_full_rounds + i));
-    }
-    //    res.extend(matrix::apply_matrix::<E>(inverse_matrix, &round_acc));
-    res.extend(&round_acc);
-    dbg!("ROUND ACC", &round_acc);
-
-    dbg!(&partial_keys.len());
-
-    while let Some(x) = partial_keys.pop() {
-        res.push(x)
-    }
-
-    // Post S-box adds for the first set of full rounds should be 'inverted' from next round.
-    for i in 1..(half_full_rounds) {
-        let start = half_full_rounds + partial_rounds;
-        let next_round = round_keys(i + start);
-        let inverted = apply_matrix::<E>(inverse_matrix, next_round);
-        res.extend(inverted);
-    }
-
-    dbg!(&res.len(), &res);
     res
 }

--- a/src/round_constants.rs
+++ b/src/round_constants.rs
@@ -2,6 +2,29 @@ pub use crate::Error;
 use ff::{PrimeField, PrimeFieldDecodingError, PrimeFieldRepr, ScalarEngine};
 pub use paired::bls12_381::Fr as Scalar;
 
+/// From the paper ():
+/// The round constants are generated using the Grain LFSR [23] in a self-shrinking
+/// mode:
+/// 1. Initialize the state with 80 bits b0, b1, . . . , b79, where
+/// (a) b0, b1 describe the field,
+/// (b) bi for 2 ≤ i ≤ 5 describe the S-Box,
+/// (c) bi for 6 ≤ i ≤ 17 are the binary representation of n,
+/// (d) bi for 18 ≤ i ≤ 29 are the binary representation of t,
+/// (e) bi for 30 ≤ i ≤ 39 are the binary representation of RF ,
+/// (f) bi for 40 ≤ i ≤ 49 are the binary representation of RP , and
+/// (g) bi for 50 ≤ i ≤ 79 are set to 1.
+/// 2. Update the bits using bi+80 = bi+62 ⊕ bi+51 ⊕ bi+38 ⊕ bi+23 ⊕ bi+13 ⊕ bi
+/// .
+/// 3. Discard the first 160 bits.
+/// 4. Evaluate bits in pairs: If the first bit is a 1, output the second bit. If it is a
+/// 0, discard the second bit.
+/// Using this method, the generation of round constants depends on the specific
+/// instance, and thus different round constants are used even if some of the chosen
+/// parameters (e.g., n and t) are the same.
+/// If a randomly sampled integer is not in Fp, we discard this value and take the
+/// next one. Note that cryptographically strong randomness is not needed for the
+/// round constants, and other methods can also be used.
+
 /// Following https://extgit.iaik.tugraz.at/krypto/hadeshash/blob/master/code/scripts/create_rcs_grain.sage
 pub fn generate_constants<E: ScalarEngine>(
     field: u8,


### PR DESCRIPTION
Optimize non-circuit performance by reducing multiplications from t^2 to 2t -1 per partial round, where t is the width.

- Compress constants by pushing them back through linear layers and through the identity components of partial layers.
- As a result, constants need only be added after each S-box.
- Having effectively moved the round-key additions into the S-boxes, refactor MDS matrices used for partial-round mix layer to use sparse matrices.
- This requires using a different (sparse) matrix at each partial round, rather than the same dense matrix at each.
  - The MDS matrix, M, for each such round, starting from the last, is factored into two components, such that M' x M'' = M.
  - M'' is sparse and replaces M for the round.
  - The previous layer's M is then replaced by M x M' = M*.
  - M* is likewise factored into M*' and M*'', and the process continues.

In order to ensure correctness, three methods are implemented:
- The original, 'naive' algorithm, along with previously established test vectors.
- A modified 'dynamic optimization', which calculates the compressed constants on the fly, in order to make the process clear. (This was also used in development as an intermediate step preserving correctness.)
- A final, 'static optimization', which uses both the compressed round constants and the derived sparse matrices — both of which are preprocessed during one-time constant generation, using the generated MDS matrix and constants for the naive algorithm as inputs.

Because accomplishing the above required manipulating matrices of field elements, I implemented some helpers. These are not used at run-time in the optimized path and are only used during preprocessing. This initial iteration is not especially efficient or general. It serves mostly to allow inversion of MDS matrices — the correctness of which is verified before use. The design goal if this code is only to facilitate the work at hand — so some further generality and expansion may be useful when optimizing circuits to reduce constraints. If preprocessing performance (time or space) needs to be improved, optimizations here are likely to help.