### PR TITLE
Feat/reduce constraints

### DIFF
--- a/parameters/round_numbers-16640-65-128-1-1.txt
+++ b/parameters/round_numbers-16640-65-128-1-1.txt
@@ -1,13 +1,13 @@
-N: 6400
+N: 16640
 Security level M: 128
 Field: Prime
 S-box: f(x) = x^5
-[8, 59, 259, 66304]
-Recommendation for N=6400, t=25:
+[8, 61, 581, 148736]
+Recommendation for N=16640, t=65:
 R_F = 8
-R_P = 59
-S-box cost = 259
-Size cost = 66304
+R_P = 61
+S-box cost = 581
+Size cost = 148736
 --- Round numbers (with security margin) ---
 Format: [Security Level, Field Size, # Elements, Field, S-Box, R_F, R_P]
 ['45', '45', '3', 'GF(2^n)', 'x^3', '8', '28']

--- a/parameters/round_numbers-4352-17-128-1-1.txt
+++ b/parameters/round_numbers-4352-17-128-1-1.txt
@@ -1,13 +1,13 @@
-N: 9472
+N: 4352
 Security level M: 128
 Field: Prime
 S-box: f(x) = x^5
-[8, 60, 356, 91136]
-Recommendation for N=9472, t=37:
+[8, 59, 195, 49920]
+Recommendation for N=4352, t=17:
 R_F = 8
-R_P = 60
-S-box cost = 356
-Size cost = 91136
+R_P = 59
+S-box cost = 195
+Size cost = 49920
 --- Round numbers (with security margin) ---
 Format: [Security Level, Field Size, # Elements, Field, S-Box, R_F, R_P]
 ['45', '45', '3', 'GF(2^n)', 'x^3', '8', '28']

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -91,7 +91,19 @@ impl<E: Engine> Elt<E> {
                 // Coalesce like terms after adding, to prevent combinatorial
                 // explosion of successive multiplications.
                 let new_lc = simplify_lc(lc + &lc2);
-                return Ok(Elt::Num(Some(new_fr), new_lc));
+                Ok(Elt::Num(Some(new_fr), new_lc))
+            }
+            (Elt::Num(Some(fr), lc), Elt::Num(None, lc2)) => {
+                let new_lc = simplify_lc(lc + &lc2);
+                Ok(Elt::Num(Some(fr), new_lc))
+            }
+            (Elt::Num(None, lc), Elt::Num(Some(fr2), lc2)) => {
+                let new_lc = simplify_lc(lc + &lc2);
+                Ok(Elt::Num(Some(fr2), new_lc))
+            }
+            (Elt::Num(None, lc), Elt::Num(None, lc2)) => {
+                let new_lc = simplify_lc(lc + &lc2);
+                Ok(Elt::Num(None, new_lc))
             }
 
             _ => panic!("only two numbers may be added"),

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -105,7 +105,6 @@ impl<E: Engine> Elt<E> {
                 let new_lc = simplify_lc(lc + &lc2);
                 Ok(Elt::Num(None, new_lc))
             }
-
             _ => panic!("only two numbers may be added"),
         }
     }
@@ -124,9 +123,19 @@ impl<E: Engine> Elt<E> {
                         acc + (fr, *variable)
                     },
                 );
+
                 Ok(Elt::Num(Some(tmp), new_lc))
             }
-            Elt::Num(None, _) => Ok(Elt::Num(None, LinearCombination::zero())),
+            Elt::Num(None, lc) => {
+                let new_lc = lc.as_ref().iter().fold(
+                    LinearCombination::zero(),
+                    |acc, (variable, mut fr)| {
+                        fr.mul_assign(&scalar);
+                        acc + (fr, *variable)
+                    },
+                );
+                Ok(Elt::Num(None, new_lc))
+            }
             Elt::Allocated(_) => Elt::Num(self.val(), self.lc()).scale::<CS>(scalar),
         }
     }

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -1,14 +1,157 @@
 use crate::poseidon::PoseidonConstants;
 
 use bellperson::gadgets::num::AllocatedNum;
-use bellperson::{ConstraintSystem, SynthesisError};
+use bellperson::{ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};
 use ff::Field;
 use ff::ScalarEngine as Engine;
 use generic_array::typenum;
 use generic_array::ArrayLength;
+use std::collections::HashMap;
 use std::marker::PhantomData;
 
-#[derive(Clone)]
+/// Similar to `num::Num`, we use `Elt` to accumulate both values and linear combinations, then eventually
+/// extract into a `num::AllocatedNum`, enforcing that the linear combination corresponds to the result.
+/// In this way, all intermediate calculations are accounted for, with the restriction that we can only
+/// accumulate linear (not polynomial) constraints. The set of operations provided here ensure this invariant is maintained.
+enum Elt<E: Engine> {
+    Allocated(AllocatedNum<E>),
+    Num(Option<E::Fr>, LinearCombination<E>),
+}
+
+impl<E: Engine> Elt<E> {
+    fn is_allocated(&self) -> bool {
+        if let Self::Allocated(_) = self {
+            true
+        } else {
+            false
+        }
+    }
+
+    fn is_num(&self) -> bool {
+        if let Self::Num(_, _) = self {
+            true
+        } else {
+            false
+        }
+    }
+
+    fn num_from_fr<CS: ConstraintSystem<E>>(fr: E::Fr) -> Self {
+        let mut lc = LinearCombination::zero();
+        lc = lc + (fr, CS::one());
+        Self::Num(Some(fr), lc)
+    }
+
+    fn ensure_allocated<CS: ConstraintSystem<E>>(
+        &self,
+        cs: &mut CS,
+        enforce: bool,
+    ) -> Result<AllocatedNum<E>, SynthesisError> {
+        match self {
+            Self::Allocated(v) => Ok(v.clone()),
+            Self::Num(fr, lc) => {
+                let v = AllocatedNum::alloc(cs.namespace(|| "allocate for Elt::Num"), || {
+                    fr.ok_or_else(|| SynthesisError::AssignmentMissing)
+                })?;
+
+                if enforce {
+                    cs.enforce(
+                        || format!("enforce num allocation preserves lc"),
+                        |_| lc.clone(),
+                        |lc| lc + CS::one(),
+                        |lc| lc + v.get_variable(),
+                    );
+                }
+                Ok(v)
+            }
+        }
+    }
+
+    fn val(&self) -> Option<E::Fr> {
+        match self {
+            Self::Allocated(v) => v.get_value(),
+            Self::Num(fr, _lc) => *fr,
+        }
+    }
+
+    fn lc(&self) -> LinearCombination<E> {
+        match self {
+            Self::Num(_fr, lc) => lc.clone(),
+            Self::Allocated(v) => LinearCombination::<E>::zero() + v.get_variable(),
+        }
+    }
+
+    /// Add two Nums and return a Num tracking the calculation. It is forbidden to invoke on an Allocated because the intended computation
+    /// doe not include that path.
+    fn add<CS: ConstraintSystem<E>>(self, other: Elt<E>) -> Result<Elt<E>, SynthesisError> {
+        match (self, other) {
+            (Elt::Num(Some(fr), lc), Elt::Num(Some(fr2), lc2)) => {
+                let mut new_fr = fr;
+                new_fr.add_assign(&fr2);
+
+                // Coalesce like terms after adding, to prevent combinatorial
+                // explosion of successive multiplications.
+                let new_lc = simplify_lc(lc + &lc2);
+                return Ok(Elt::Num(Some(new_fr), new_lc));
+            }
+
+            _ => panic!("only two numbers may be added"),
+        }
+    }
+
+    /// Scale
+    fn scale<CS: ConstraintSystem<E>>(&self, scalar: E::Fr) -> Result<Elt<E>, SynthesisError> {
+        match self {
+            Elt::Num(Some(fr), lc) => {
+                let mut tmp = *fr;
+                tmp.mul_assign(&scalar);
+
+                let new_lc = lc.as_ref().iter().fold(
+                    LinearCombination::zero(),
+                    |acc, (variable, mut fr)| {
+                        fr.mul_assign(&scalar);
+                        acc + (fr, *variable)
+                    },
+                );
+                Ok(Elt::Num(Some(tmp), new_lc))
+            }
+            Elt::Num(None, _) => Ok(Elt::Num(None, LinearCombination::zero())),
+            Elt::Allocated(_) => Elt::Num(self.val(), self.lc()).scale::<CS>(scalar),
+        }
+    }
+}
+
+fn simplify_lc<E: Engine>(lc: LinearCombination<E>) -> LinearCombination<E> {
+    #[derive(PartialEq, Eq, Debug, std::hash::Hash)]
+    enum Idx {
+        Input(usize),
+        Aux(usize),
+    }
+
+    let mut map: HashMap<Idx, E::Fr> = HashMap::new();
+
+    lc.as_ref().iter().for_each(|(var, fr)| {
+        let key = match var.get_unchecked() {
+            Index::Input(i) => Idx::Input(i),
+            Index::Aux(i) => Idx::Aux(i),
+        };
+
+        let val = map.entry(key).or_insert(E::Fr::zero());
+        val.add_assign(fr)
+    });
+
+    let simplified = map
+        .iter()
+        .fold(LinearCombination::<E>::zero(), |acc, (idx, &fr)| {
+            let index = match idx {
+                Idx::Input(i) => Index::Input(*i),
+                Idx::Aux(i) => Index::Aux(*i),
+            };
+            acc + (fr, Variable::new_unchecked(index))
+        });
+    simplified
+}
+
+//#[derive(Clone)]
 /// Circuit for Poseidon hash.
 pub struct PoseidonCircuit<'a, E, Arity>
 where
@@ -20,7 +163,7 @@ where
 {
     constants_offset: usize,
     width: usize,
-    elements: Vec<AllocatedNum<E>>,
+    elements: Vec<Elt<E>>,
     pos: usize,
     constants: &'a PoseidonConstants<E, Arity>,
     _w: PhantomData<Arity>,
@@ -36,9 +179,12 @@ where
     typenum::Add1<Arity>: ArrayLength<E::Fr>,
 {
     /// Create a new Poseidon hasher for `preimage`.
-    pub fn new(elements: Vec<AllocatedNum<E>>, constants: &'a PoseidonConstants<E, Arity>) -> Self {
+    pub fn new(
+        allocated_nums: Vec<AllocatedNum<E>>,
+        constants: &'a PoseidonConstants<E, Arity>,
+    ) -> Self {
         let width = constants.width();
-
+        let elements = allocated_nums.into_iter().map(Elt::Allocated).collect();
         PoseidonCircuit {
             constants_offset: 0,
             width,
@@ -53,8 +199,6 @@ where
         &mut self,
         mut cs: CS,
     ) -> Result<AllocatedNum<E>, SynthesisError> {
-        // This counter is incremented when a round constants is read. Therefore, the round constants never
-        // repeat
         for i in 0..self.constants.full_rounds / 2 {
             self.full_round(cs.namespace(|| format!("initial full round {}", i)))?;
         }
@@ -67,7 +211,7 @@ where
             self.full_round(cs.namespace(|| format!("final full round {}", i)))?;
         }
 
-        Ok(self.elements[1].clone())
+        self.elements[1].ensure_allocated(&mut cs.namespace(|| "hash result"), true)
     }
 
     fn full_round<CS: ConstraintSystem<E>>(&mut self, mut cs: CS) -> Result<(), SynthesisError> {
@@ -81,13 +225,13 @@ where
             self.elements[i] = quintic_s_box(
                 cs.namespace(|| format!("quintic s-box {}", i)),
                 &self.elements[i],
-                Some(round_key),
+                round_key,
             )?
         }
         self.constants_offset = constants_offset;
 
         // Multiply the elements by the constant MDS matrix
-        self.product_mds(cs.namespace(|| "mds matrix product"), false)?;
+        self.product_mds::<CS>(false)?;
         Ok(())
     }
 
@@ -98,26 +242,25 @@ where
         self.elements[0] = quintic_s_box(
             cs.namespace(|| "solitary quintic s-box"),
             &self.elements[0],
-            Some(round_key),
+            round_key,
         )?;
 
         // Multiply the elements by the constant MDS matrix
-        self.product_mds(cs.namespace(|| "mds matrix product"), true)?;
+        self.product_mds::<CS>(true)?;
 
         Ok(())
     }
 
     fn product_mds<CS: ConstraintSystem<E>>(
         &mut self,
-        mut cs: CS,
-        add_round_keys: bool,
+        partial_round: bool,
     ) -> Result<(), SynthesisError> {
-        let mut result: Vec<AllocatedNum<E>> = Vec::with_capacity(self.constants.width());
+        let mut result: Vec<Elt<E>> = Vec::with_capacity(self.constants.width());
 
         for j in 0..self.constants.width() {
             let column = self.constants.mds_matrices.m[j].to_vec();
             // TODO: This could be cached per round to save synthesis time.
-            let constant_term = if add_round_keys {
+            let product = if partial_round {
                 let mut acc = E::Fr::zero();
                 // Dot product of column and this round's keys.
                 for k in 1..self.constants.width() {
@@ -126,20 +269,15 @@ where
                     tmp.mul_assign(&rk);
                     acc.add_assign(&tmp);
                 }
-                Some(acc)
-            } else {
-                None
-            };
 
-            let product = scalar_product(
-                cs.namespace(|| format!("scalar product {}", j)),
-                self.elements.as_slice(),
-                &column,
-                constant_term,
-            )?;
+                scalar_product_with_add::<E, CS>(self.elements.as_slice(), &column, acc)
+            } else {
+                scalar_product::<E, CS>(self.elements.as_slice(), &column)
+            }?;
+
             result.push(product);
         }
-        if add_round_keys {
+        if partial_round {
             self.constants_offset += self.constants.width() - 1;
         }
         self.elements = result;
@@ -148,54 +286,8 @@ where
     }
 
     fn debug(&self) {
-        let element_frs: Vec<_> = self.elements.iter().map(|n| n.get_value()).collect();
+        let element_frs: Vec<_> = self.elements.iter().map(|n| n.val()).collect::<Vec<_>>();
         dbg!(element_frs, self.constants_offset);
-    }
-
-    /// This works but is inefficient. Retained for reference.
-    fn partial_round_with_explicit_round_constants<CS: ConstraintSystem<E>>(
-        &mut self,
-        mut cs: CS,
-    ) -> Result<(), SynthesisError> {
-        let round_key = self.constants.round_constants[self.constants_offset];
-        self.constants_offset += 1;
-        // Apply the quintic S-Box to the first element.
-        self.elements[0] = quintic_s_box(
-            cs.namespace(|| "solitary quintic s-box"),
-            &self.elements[0],
-            Some(round_key),
-        )?;
-
-        self.add_round_constants(cs.namespace(|| "add round keys"), true)?;
-
-        // Multiply the elements by the constant MDS matrix
-        self.product_mds(cs.namespace(|| "mds matrix product"), false)?;
-
-        Ok(())
-    }
-
-    fn add_round_constants<CS: ConstraintSystem<E>>(
-        &mut self,
-        mut cs: CS,
-        skip_first: bool,
-    ) -> Result<(), SynthesisError> {
-        let mut constants_offset = self.constants_offset;
-        let start = if skip_first { 1 } else { 0 };
-
-        for i in start..self.elements.len() {
-            let constant = &self.constants.round_constants[constants_offset];
-            constants_offset += 1;
-
-            self.elements[i] = add(
-                cs.namespace(|| format!("add round key {}", i)),
-                &self.elements[i],
-                constant,
-            )?;
-        }
-
-        self.constants_offset = constants_offset;
-
-        Ok(())
     }
 }
 
@@ -214,61 +306,30 @@ where
     typenum::Add1<Arity>: ArrayLength<E::Fr>,
 {
     // Add the arity tag to the front of the preimage.
-    let tag = constants.arity_tag; // This could be shared across hash invocations within a circuit. TODO: add a mechanism for any such shared allocations.
+    let tag = constants.arity_tag;
     let tag_num = AllocatedNum::alloc(cs.namespace(|| "arity tag"), || Ok(tag))?;
     preimage.push(tag_num);
     preimage.rotate_right(1);
+
     let mut p = PoseidonCircuit::new(preimage, constants);
 
     p.hash(cs)
 }
 
-pub fn create_poseidon_parameters<'a, E, Arity>() -> PoseidonConstants<E, Arity>
-where
-    E: Engine,
-    Arity: typenum::Unsigned
-        + std::ops::Add<typenum::bit::B1>
-        + std::ops::Add<typenum::uint::UInt<typenum::uint::UTerm, typenum::bit::B1>>,
-    typenum::Add1<Arity>: ArrayLength<E::Fr>,
-{
-    PoseidonConstants::new()
-}
-
-pub fn poseidon_hash_simple<CS, E, Arity>(
-    cs: CS,
-    preimage: Vec<AllocatedNum<E>>,
-) -> Result<AllocatedNum<E>, SynthesisError>
-where
-    CS: ConstraintSystem<E>,
-    E: Engine,
-    Arity: typenum::Unsigned
-        + std::ops::Add<typenum::bit::B1>
-        + std::ops::Add<typenum::uint::UInt<typenum::uint::UTerm, typenum::bit::B1>>,
-    typenum::Add1<Arity>: ArrayLength<E::Fr>,
-{
-    poseidon_hash(cs, preimage, &create_poseidon_parameters::<E, Arity>())
-}
-
 /// Compute l^5 and enforce constraint. If round_key is supplied, add it to l first.
 fn quintic_s_box<CS: ConstraintSystem<E>, E: Engine>(
     mut cs: CS,
-    l: &AllocatedNum<E>,
-    round_key: Option<E::Fr>,
-) -> Result<AllocatedNum<E>, SynthesisError> {
-    // If round_key was supplied, add it to l before squaring.
-    let l2 = if let Some(rk) = round_key {
-        square_sum(cs.namespace(|| "(l+rk)^2"), rk, l)?
-    } else {
-        l.square(cs.namespace(|| "l^2"))?
-    };
-    let l4 = l2.square(cs.namespace(|| "l^4"))?;
-    let l5 = if let Some(rk) = round_key {
-        mul_sum(cs.namespace(|| "l4 * (l + rk)"), &l4, &l, rk)
-    } else {
-        l4.mul(cs.namespace(|| "l^5"), &l)
-    };
+    e: &Elt<E>,
+    round_key: E::Fr,
+) -> Result<Elt<E>, SynthesisError> {
+    let l = e.ensure_allocated(&mut cs.namespace(|| "S-box input"), true)?;
 
-    l5
+    // If round_key was supplied, add it to l before squaring.
+    let l2 = square_sum(cs.namespace(|| "(l+rk)^2"), round_key, &l, true)?;
+    let l4 = l2.square(cs.namespace(|| "l^4"))?;
+    let l5 = mul_sum(cs.namespace(|| "l4 * (l + rk)"), &l4, &l, round_key, true);
+
+    Ok(Elt::Allocated(l5?))
 }
 
 /// Calculates square of sum and enforces that constraint.
@@ -276,6 +337,7 @@ pub fn square_sum<CS: ConstraintSystem<E>, E: Engine>(
     mut cs: CS,
     to_add: E::Fr,
     num: &AllocatedNum<E>,
+    enforce: bool,
 ) -> Result<AllocatedNum<E>, SynthesisError>
 where
     CS: ConstraintSystem<E>,
@@ -290,12 +352,14 @@ where
         Ok(tmp)
     })?;
 
-    cs.enforce(
-        || "squared sum constraint",
-        |lc| lc + num.get_variable() + (to_add, CS::one()),
-        |lc| lc + num.get_variable() + (to_add, CS::one()),
-        |lc| lc + res.get_variable(),
-    );
+    if enforce {
+        cs.enforce(
+            || "squared sum constraint",
+            |lc| lc + num.get_variable() + (to_add, CS::one()),
+            |lc| lc + num.get_variable() + (to_add, CS::one()),
+            |lc| lc + res.get_variable(),
+        );
+    }
     Ok(res)
 }
 
@@ -305,6 +369,7 @@ pub fn mul_sum<CS: ConstraintSystem<E>, E: Engine>(
     a: &AllocatedNum<E>,
     b: &AllocatedNum<E>,
     to_add: E::Fr,
+    enforce: bool,
 ) -> Result<AllocatedNum<E>, SynthesisError>
 where
     CS: ConstraintSystem<E>,
@@ -322,146 +387,36 @@ where
         Ok(tmp)
     })?;
 
-    cs.enforce(
-        || "mul sum constraint",
-        |lc| lc + b.get_variable() + (to_add, CS::one()),
-        |lc| lc + a.get_variable(),
-        |lc| lc + res.get_variable(),
-    );
+    if enforce {
+        cs.enforce(
+            || "mul sum constraint",
+            |lc| lc + b.get_variable() + (to_add, CS::one()),
+            |lc| lc + a.get_variable(),
+            |lc| lc + res.get_variable(),
+        );
+    }
     Ok(res)
 }
 
-/// Adds a constraint to CS, enforcing that a + b = sum.
-///
-/// a + b = sum
-fn sum<E: Engine, A, AR, CS: ConstraintSystem<E>>(
-    cs: &mut CS,
-    annotation: A,
-    a: &AllocatedNum<E>,
-    b: &AllocatedNum<E>,
-    sum: &AllocatedNum<E>,
-) where
-    A: FnOnce() -> AR,
-    AR: Into<String>,
-{
-    // (a + b) * 1 = sum
-    cs.enforce(
-        annotation,
-        |lc| lc + a.get_variable() + b.get_variable(),
-        |lc| lc + CS::one(),
-        |lc| lc + sum.get_variable(),
-    );
-}
+fn scalar_product_with_add<E: Engine, CS: ConstraintSystem<E>>(
+    elts: &[Elt<E>],
+    scalars: &[E::Fr],
+    to_add: E::Fr,
+) -> Result<Elt<E>, SynthesisError> {
+    let tmp = scalar_product::<E, CS>(elts, scalars)?;
+    let tmp2 = tmp.add::<CS>(Elt::<E>::num_from_fr::<CS>(to_add))?;
 
-/// Adds a constraint to CS, enforcing that sum is the sum of nums.
-fn multi_sum<E: Engine, A, AR, CS: ConstraintSystem<E>>(
-    cs: &mut CS,
-    annotation: A,
-    nums: &[AllocatedNum<E>],
-    sum: &AllocatedNum<E>,
-) where
-    A: FnOnce() -> AR,
-    AR: Into<String>,
-{
-    // (num[0] + num[1] + … + num[n]) * 1 = sum
-    cs.enforce(
-        annotation,
-        |lc| nums.iter().fold(lc, |acc, num| acc + num.get_variable()),
-        |lc| lc + CS::one(),
-        |lc| lc + sum.get_variable(),
-    );
-}
-
-fn add<E: Engine, CS: ConstraintSystem<E>>(
-    mut cs: CS,
-    a: &AllocatedNum<E>,
-    b: &E::Fr,
-) -> Result<AllocatedNum<E>, SynthesisError> {
-    let sum = AllocatedNum::alloc(cs.namespace(|| "add"), || {
-        let mut tmp = a
-            .get_value()
-            .ok_or_else(|| SynthesisError::AssignmentMissing)?;
-        tmp.add_assign(b);
-
-        Ok(tmp)
-    })?;
-
-    // a + b = sum
-    cs.enforce(
-        || "sum constraint",
-        |lc| lc + a.get_variable() + (*b, CS::one()),
-        |lc| lc + CS::one(),
-        |lc| lc + sum.get_variable(),
-    );
-
-    Ok(sum)
-}
-
-fn multi_add<E: Engine, CS: ConstraintSystem<E>>(
-    mut cs: CS,
-    nums: &[AllocatedNum<E>],
-) -> Result<AllocatedNum<E>, SynthesisError> {
-    let res = AllocatedNum::alloc(cs.namespace(|| "multi_add"), || {
-        nums.iter().try_fold(E::Fr::zero(), |mut acc, num| {
-            acc.add_assign(
-                &num.get_value()
-                    .ok_or_else(|| SynthesisError::AssignmentMissing)?,
-            );
-            Ok(acc)
-        })
-    })?;
-
-    // a + b = res
-    multi_sum(&mut cs, || "sum constraint", nums, &res);
-
-    Ok(res)
+    Ok(tmp2)
 }
 
 fn scalar_product<E: Engine, CS: ConstraintSystem<E>>(
-    mut cs: CS,
-    nums: &[AllocatedNum<E>],
+    elts: &[Elt<E>],
     scalars: &[E::Fr],
-    to_add: Option<E::Fr>,
-) -> Result<AllocatedNum<E>, SynthesisError> {
-    let product = AllocatedNum::alloc(cs.namespace(|| "scalar product"), || {
-        let tmp: Result<E::Fr, SynthesisError> =
-            nums.iter()
-                .zip(scalars)
-                .try_fold(E::Fr::zero(), |mut acc, (num, scalar)| {
-                    let mut x = num
-                        .get_value()
-                        .ok_or_else(|| SynthesisError::AssignmentMissing)?;
-                    x.mul_assign(scalar);
-                    acc.add_assign(&x);
-                    Ok(acc)
-                });
-
-        let mut tmp2 = tmp?;
-        if let Some(a) = to_add {
-            tmp2.add_assign(&a);
-        }
-        Ok(tmp2)
-    })?;
-
-    cs.enforce(
-        || "scalar product constraint",
-        |lc| {
-            let base = scalars
-                .iter()
-                .zip(nums)
-                .fold(lc, |acc, (scalar, num)| acc + (*scalar, num.get_variable()));
-
-            if let Some(a) = to_add {
-                base + (a, CS::one())
-            } else {
-                base
-            }
-        },
-        |lc| lc + CS::one(),
-        |lc| lc + product.get_variable(),
-    );
-
-    Ok(product)
+) -> Result<Elt<E>, SynthesisError> {
+    elts.iter().zip(scalars).try_fold(
+        Elt::Num(Some(E::Fr::zero()), { LinearCombination::<E>::zero() }),
+        |acc, (elt, &scalar)| acc.add::<CS>(elt.scale::<CS>(scalar)?),
+    )
 }
 
 #[cfg(test)]
@@ -474,81 +429,99 @@ mod tests {
     use paired::bls12_381::{Bls12, Fr};
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
+    use std::ops::Add;
+    use typenum::bit::B1;
+    use typenum::marker_traits::Unsigned;
+    use typenum::uint::{UInt, UTerm};
+    use typenum::Add1;
 
     #[test]
     fn test_poseidon_hash() {
-        let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
-
-        // TODO: add this exact calculation into the test.
-        // (It correctly yields the values in the cases below.)
-        // (defun constraints (arity rp &optional (rf 8))
-        //  (let* ((width (1+ arity))
-        //         (s-boxes (+ (* width rf) rp))
-        //         (s-box-constraints (* 3 s-boxes))
-        //         (mds-constraints (* width (+ rf rp))))
-        //   (+ s-box-constraints mds-constraints)))
-        let cases = [
-            (2, 426),
-            (4, 608),
-            (8, 972),
-            (16, 764),
-            (24, 1012),
-            (36, 1388),
-        ];
-
-        // TODO: test multiple arities.
-        let test_arity = 2;
-
-        for (arity, constraints) in &cases {
-            if *arity != test_arity {
-                continue;
-            }
-            let mut cs = TestConstraintSystem::<Bls12>::new();
-            let mut i = 0;
-
-            let mut fr_data = vec![Fr::zero(); test_arity];
-            let data: Vec<AllocatedNum<Bls12>> = (0..*arity)
-                .enumerate()
-                .map(|_| {
-                    let fr = Fr::random(&mut rng);
-                    fr_data[i] = fr;
-                    i += 1;
-                    AllocatedNum::alloc(cs.namespace(|| format!("data {}", i)), || Ok(fr)).unwrap()
-                })
-                .collect::<Vec<_>>();
-
-            let constants = PoseidonConstants::new();
-            let out = poseidon_hash(&mut cs, data, &constants).expect("poseidon hashing failed");
-
-            let mut p = Poseidon::<Bls12>::new_with_preimage(&fr_data, &constants);
-            let expected: Fr = p.hash_in_mode(HashMode::Correct);
-
-            assert!(cs.is_satisfied(), "constraints not satisfied");
-
-            assert_eq!(
-                expected,
-                out.get_value().unwrap(),
-                "circuit and non-circuit do not match"
-            );
-
-            assert_eq!(
-                cs.num_constraints(),
-                *constraints,
-                "constraint size changed",
-            );
-        }
+        test_poseidon_hash_aux::<typenum::U2>(314);
+        test_poseidon_hash_aux::<typenum::U4>(380);
+        test_poseidon_hash_aux::<typenum::U8>(508);
+        test_poseidon_hash_aux::<typenum::U16>(764);
+        test_poseidon_hash_aux::<typenum::U24>(1012);
+        test_poseidon_hash_aux::<typenum::U36>(1388);
     }
+    fn test_poseidon_hash_aux<Arity>(expected_constraints: usize)
+    where
+        Arity: Unsigned + Add<B1> + Add<UInt<UTerm, B1>>,
+        Add1<Arity>: ArrayLength<<Bls12 as Engine>::Fr>,
+    {
+        let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
+        let mut cs = TestConstraintSystem::<Bls12>::new();
+        let arity = Arity::to_usize();
+        let constants = PoseidonConstants::<Bls12, Arity>::new();
+
+        let expected_constraints_calculated = {
+            let width = 1 + arity;
+            let s_boxes = (width * constants.full_rounds) + constants.partial_rounds;
+            let s_box_constraints = 3 * s_boxes;
+            let mds_constraints =
+                (width * constants.full_rounds) + constants.partial_rounds - arity;
+            let total_constraints = s_box_constraints + mds_constraints;
+
+            total_constraints
+        };
+        let mut i = 0;
+
+        let mut fr_data = vec![Fr::zero(); arity];
+        let data: Vec<AllocatedNum<Bls12>> = (0..arity)
+            .enumerate()
+            .map(|_| {
+                let fr = Fr::random(&mut rng);
+                fr_data[i] = fr;
+                i += 1;
+                AllocatedNum::alloc(cs.namespace(|| format!("data {}", i)), || Ok(fr)).unwrap()
+            })
+            .collect::<Vec<_>>();
+
+        let out = poseidon_hash(&mut cs, data, &constants).expect("poseidon hashing failed");
+
+        let mut p = Poseidon::<Bls12, Arity>::new_with_preimage(&fr_data, &constants);
+        let expected: Fr = p.hash_in_mode(HashMode::Correct);
+
+        assert!(cs.is_satisfied(), "constraints not satisfied");
+
+        assert_eq!(
+            expected,
+            out.get_value().unwrap(),
+            "circuit and non-circuit do not match"
+        );
+
+        assert_eq!(
+            expected_constraints_calculated,
+            cs.num_constraints(),
+            "constraint number miscalculated"
+        );
+
+        assert_eq!(
+            expected_constraints,
+            cs.num_constraints(),
+            "constraint number changed",
+        );
+    }
+
+    fn fr(n: u64) -> <Bls12 as Engine>::Fr {
+        scalar_from_u64::<Bls12>(n)
+    }
+
+    fn efr(n: u64) -> Elt<Bls12> {
+        Elt::num_from_fr::<TestConstraintSystem<Bls12>>(fr(n))
+    }
+
     #[test]
     fn test_square_sum() {
         let mut cs = TestConstraintSystem::<Bls12>::new();
 
         let mut cs1 = cs.namespace(|| "square_sum");
-        let two = scalar_from_u64::<Bls12>(2);
+        let two = fr(2);
         let three = AllocatedNum::alloc(cs1.namespace(|| "three"), || {
             Ok(scalar_from_u64::<Bls12>(3))
         })
         .unwrap();
-        let res = square_sum(cs1, two, &three).unwrap();
+        let res = square_sum(cs1, two, &three, true).unwrap();
 
         let twenty_five: Fr = scalar_from_u64::<Bls12>(25);
         assert_eq!(twenty_five, res.get_value().unwrap());
@@ -556,52 +529,135 @@ mod tests {
 
     #[test]
     fn test_scalar_product() {
-        let mut cs = TestConstraintSystem::<Bls12>::new();
-        let two = AllocatedNum::alloc(cs.namespace(|| "two"), || Ok(scalar_from_u64::<Bls12>(2)))
-            .unwrap();
-        let three =
-            AllocatedNum::alloc(cs.namespace(|| "three"), || Ok(scalar_from_u64::<Bls12>(3)))
-                .unwrap();
-        let four = AllocatedNum::alloc(cs.namespace(|| "four"), || Ok(scalar_from_u64::<Bls12>(4)))
+        {
+            // Inputs are all linear combinations.
+            let two = efr(2);
+            let three = efr(3);
+            let four = efr(4);
+
+            let res = scalar_product::<Bls12, TestConstraintSystem<Bls12>>(
+                &[two, three, four],
+                &[fr(5), fr(6), fr(7)],
+            )
             .unwrap();
 
-        let res = scalar_product(
-            cs,
-            &[two, three, four],
-            &[
-                scalar_from_u64::<Bls12>(5),
-                scalar_from_u64::<Bls12>(6),
-                scalar_from_u64::<Bls12>(7),
-            ],
-            None,
-        )
-        .unwrap();
+            assert!(res.is_num());
+            assert_eq!(scalar_from_u64::<Bls12>(56), res.val().unwrap());
+        }
+        {
+            let mut cs = TestConstraintSystem::<Bls12>::new();
 
-        assert_eq!(scalar_from_u64::<Bls12>(56), res.get_value().unwrap());
+            // Inputs are linear combinations and an allocated number.
+            let two = efr(2);
+
+            let n3 =
+                AllocatedNum::alloc(cs.namespace(|| "three"), || Ok(scalar_from_u64::<Bls12>(3)))
+                    .unwrap();
+            let three = Elt::Allocated(n3.clone());
+            let n4 =
+                AllocatedNum::alloc(cs.namespace(|| "four"), || Ok(scalar_from_u64::<Bls12>(4)))
+                    .unwrap();
+            let four = Elt::Allocated(n4.clone());
+
+            let res = scalar_product::<Bls12, TestConstraintSystem<Bls12>>(
+                &[two, three, four],
+                &[fr(5), fr(6), fr(7)],
+            )
+            .unwrap();
+
+            assert!(res.is_num());
+            assert_eq!(scalar_from_u64::<Bls12>(56), res.val().unwrap());
+
+            res.lc().as_ref().iter().for_each(|(var, f)| {
+                if var.get_unchecked() == n3.get_variable().get_unchecked() {
+                    assert_eq!(*f, fr(6));
+                };
+                if var.get_unchecked() == n4.get_variable().get_unchecked() {
+                    assert_eq!(*f, fr(7));
+                };
+            });
+
+            res.ensure_allocated(&mut cs, true).unwrap();
+            assert!(cs.is_satisfied());
+        }
+        {
+            let mut cs = TestConstraintSystem::<Bls12>::new();
+
+            // Inputs are linear combinations and an allocated number.
+            let two = efr(2);
+
+            let n3 =
+                AllocatedNum::alloc(cs.namespace(|| "three"), || Ok(scalar_from_u64::<Bls12>(3)))
+                    .unwrap();
+            let three = Elt::Allocated(n3.clone());
+            let n4 =
+                AllocatedNum::alloc(cs.namespace(|| "four"), || Ok(scalar_from_u64::<Bls12>(4)))
+                    .unwrap();
+            let four = Elt::Allocated(n4.clone());
+
+            let mut res_vec = Vec::new();
+
+            let res = scalar_product::<Bls12, TestConstraintSystem<Bls12>>(
+                &[two, three, four],
+                &[fr(5), fr(6), fr(7)],
+            )
+            .unwrap();
+
+            res_vec.push(res);
+
+            assert!(res_vec[0].is_num());
+            assert_eq!(fr(56), res_vec[0].val().unwrap());
+
+            res_vec[0].lc().as_ref().iter().for_each(|(var, f)| {
+                if var.get_unchecked() == n3.get_variable().get_unchecked() {
+                    assert_eq!(*f, fr(6)); // 6 * three
+                };
+                if var.get_unchecked() == n4.get_variable().get_unchecked() {
+                    assert_eq!(*f, fr(7)); // 7 * four
+                };
+            });
+
+            let four2 = Elt::Allocated(n4.clone());
+            res_vec.push(efr(3));
+            res_vec.push(four2);
+            let res2 = scalar_product::<Bls12, TestConstraintSystem<Bls12>>(
+                &res_vec,
+                &[fr(7), fr(8), fr(9)],
+            )
+            .unwrap();
+
+            res2.lc().as_ref().iter().for_each(|(var, f)| {
+                if var.get_unchecked() == n3.get_variable().get_unchecked() {
+                    assert_eq!(*f, fr(42)); // 7 * 6 * three
+                };
+                if var.get_unchecked() == n4.get_variable().get_unchecked() {
+                    assert_eq!(*f, fr(58)); // (7 * 7 * four) + (9 * four)
+                };
+            });
+
+            let allocated = res2.ensure_allocated(&mut cs, true).unwrap();
+
+            let v = allocated.get_value().unwrap();
+            assert_eq!(fr(452), v); // (7 * 56) + (8 * 3) + (9 * 4) = 448
+
+            assert!(cs.is_satisfied());
+        }
     }
+
     #[test]
     fn test_scalar_product_with_add() {
-        let mut cs = TestConstraintSystem::<Bls12>::new();
-        let two = AllocatedNum::alloc(cs.namespace(|| "two"), || Ok(scalar_from_u64::<Bls12>(2)))
-            .unwrap();
-        let three =
-            AllocatedNum::alloc(cs.namespace(|| "three"), || Ok(scalar_from_u64::<Bls12>(3)))
-                .unwrap();
-        let four = AllocatedNum::alloc(cs.namespace(|| "four"), || Ok(scalar_from_u64::<Bls12>(4)))
-            .unwrap();
+        let two = efr(2);
+        let three = efr(3);
+        let four = efr(4);
 
-        let res = scalar_product(
-            cs,
+        let res = scalar_product_with_add::<Bls12, TestConstraintSystem<Bls12>>(
             &[two, three, four],
-            &[
-                scalar_from_u64::<Bls12>(5),
-                scalar_from_u64::<Bls12>(6),
-                scalar_from_u64::<Bls12>(7),
-            ],
-            Some(scalar_from_u64::<Bls12>(3)),
+            &[fr(5), fr(6), fr(7)],
+            fr(3),
         )
         .unwrap();
 
-        assert_eq!(scalar_from_u64::<Bls12>(59), res.get_value().unwrap());
+        assert!(res.is_num());
+        assert_eq!(fr(59), res.val().unwrap());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub fn round_numbers(arity: usize) -> (usize, usize) {
         8 | 9 | 10 | 11 | 12 => 57,
         17 | 25 => 59,
         37 => 60,
+        65 => 61,
         //24 => 42, // Just for a comparative benchmark — don't use this.
         _ => panic!(format!("unsupported arity {}", arity)),
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,8 +28,7 @@ pub fn round_numbers(arity: usize) -> (usize, usize) {
     let full_rounds = 8;
     let partial_rounds = match width {
         2 | 3 => 55,
-        //4 | 5 | 6 | 7 => 56,
-        4 | 5 | 6 | 7 => 5,
+        4 | 5 | 6 | 7 => 56,
         8 | 9 | 10 | 11 | 12 => 57,
         17 | 25 => 59,
         37 => 60,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,8 @@ pub fn round_numbers(arity: usize) -> (usize, usize) {
     let full_rounds = 8;
     let partial_rounds = match width {
         2 | 3 => 55,
-        4 | 5 | 6 | 7 => 56,
+        //4 | 5 | 6 | 7 => 56,
+        4 | 5 | 6 | 7 => 5,
         8 | 9 | 10 | 11 | 12 => 57,
         17 | 25 => 59,
         37 => 60,

--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -547,7 +547,6 @@ where
                 let sparse_matrix = &self.constants.sparse_matrices[index];
 
                 self.product_mds_with_sparse_matrix(&sparse_matrix);
-            //self.product_mds_with_matrix(&sparse_matrix);
             } else {
                 self.product_mds();
             }


### PR DESCRIPTION
This reduces the number of constraints to just those for the S-boxes. Intermediate results of MDS products accumulate in linear combinations, paired with intermediate results. We allocate a variable corresponding to these well-formed linear combinations and their associated value before each non-linear S-box transformation, which enforce the non-linear constraints. A final constraint is enforced on the result value extracted from the first element of the state.