### PR TITLE
fast frs_2d_to_u64s

### DIFF
--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -170,18 +170,22 @@ where
 }
 
 fn frs_to_u64s(frs: &[Fr]) -> Vec<u64> {
-    let mut res = vec![u64::default(); frs.len() * 4];
-    for (src, dest) in frs.iter().zip(res.chunks_mut(4)) {
-        dest.copy_from_slice(&src.into_repr().0);
+    let mut out = Vec::with_capacity(frs.len() * 4);
+    for fr in frs.iter() {
+        out.extend_from_slice(&fr.into_repr().0);
     }
-    res
+    out
 }
 
 fn frs_2d_to_u64s(frs_2d: &[Vec<Fr>]) -> Vec<u64> {
-    frs_2d
-        .iter()
-        .flat_map(|row| frs_to_u64s(row).into_iter())
-        .collect()
+    let len = frs_2d.iter().map(|row| row.len() * 4).sum();
+    let mut out: Vec<u64> = Vec::with_capacity(len);
+    for row in frs_2d.iter() {
+        for fr in row.iter() {
+            out.extend_from_slice(&fr.into_repr().0);
+        }
+    }
+    out
 }
 
 fn array_u64_1d_from_fr(ctx: &FutharkContext, fr: Fr) -> Result<Array_u64_1d, Error> {


### PR DESCRIPTION

```rust
#![feature(test)]
extern crate test;


#[derive(Debug, Clone, Copy)]
pub struct Fr([u64; 4]);


fn frs_2d_to_u64s(frs_2d: &[Vec<Fr>]) -> Vec<u64> {
    frs_2d
        .iter()
        .flat_map(|row| frs_to_u64s(row).into_iter())
        .collect()
}

fn frs_2d_to_u64s_fast(frs_2d: &[Vec<Fr>]) -> Vec<u64> {
    let mut out: Vec<u64> = Vec::new();
    for row in frs_2d.iter() {
        for fr in row.iter() {
            out.extend_from_slice(&fr.0);
        }
    }
    out
}

fn frs_2d_to_u64s_fast2(frs_2d: &[Vec<Fr>]) -> Vec<u64> {
    let len = frs_2d.iter().map(|row| row.len() * 4).sum();
    let mut out: Vec<u64> = Vec::with_capacity(len);
    for row in frs_2d.iter() {
        for fr in row.iter() {
            out.extend_from_slice(&fr.0);
        }
    }
    out
}

#[bench]
fn bench_frs_2d_to_u64s(b: &mut test::Bencher) {
    let data = vec![ vec![ Fr([0u64; 4]); 32 ]; 11];

    b.iter(|| {
        frs_2d_to_u64s(&data)
    })
}

#[bench]
fn bench_frs_2d_to_u64s_fast(b: &mut test::Bencher) {
    let data = vec![ vec![ Fr([0u64; 4]); 32 ]; 11];

    b.iter(|| {
        frs_2d_to_u64s_fast(&data)
    })
}

#[bench]
fn bench_frs_2d_to_u64s_fast2(b: &mut test::Bencher) {
    let data = vec![ vec![ Fr([0u64; 4]); 32 ]; 11];

    b.iter(|| {
        frs_2d_to_u64s_fast2(&data)
    })
}


fn frs_to_u64s(frs: &[Fr]) -> Vec<u64> {
    let mut res = vec![u64::default(); frs.len() * 4];
    for (src, dest) in frs.iter().zip(res.chunks_mut(4)) {
        dest.copy_from_slice(&src.0);
    }
    res
}

fn frs_to_u64s_fast(frs: &[Fr]) -> Vec<u64> {
    let len = frs.len() * 4;
    let mut out = Vec::with_capacity(len);

    for (i, fr) in frs.iter().enumerate() {
        out.extend_from_slice(&fr.0);
    }
    out
}

#[bench]
fn bench_frs_to_u64s(b: &mut test::Bencher) {
    let data = vec![ Fr([0u64; 4]); 32 ];

    b.iter(|| {
        frs_to_u64s(&data)
    })
}

#[bench]
fn bench_frs_to_u64s_fast(b: &mut test::Bencher) {
    let data = vec![ Fr([0u64; 4]); 32 ];

    b.iter(|| {
        frs_to_u64s_fast(&data)
    })
}

```

Result:

```
test bench_frs_2d_to_u64s       ... bench:       5,040 ns/iter (+/- 665)
test bench_frs_2d_to_u64s_fast  ... bench:       3,434 ns/iter (+/- 571)
test bench_frs_2d_to_u64s_fast2 ... bench:       1,042 ns/iter (+/- 71)
test bench_frs_to_u64s          ... bench:         250 ns/iter (+/- 14)
test bench_frs_to_u64s_fast     ... bench:         160 ns/iter (+/- 9)
```