### PR TITLE
Use nepton-triton with no build-time bindgen.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ byteorder = "1"
 ff = { version = "0.2.1", package = "fff" }
 generic-array = "0.13.2"
 paired = "0.18.0"
-triton = { version = "0.2.0", package = "neptune-triton", default-features=false, features=["opencl"], optional=true }
+triton = { version = "0.2.1", package = "neptune-triton", default-features=false, features=["opencl"], optional=true }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/gbench/Cargo.toml
+++ b/gbench/Cargo.toml
@@ -16,5 +16,4 @@ ff = { version = "0.2.1", package = "fff" }
 generic-array = "0.13.2"
 log = "0.4.8"
 paired = "0.18.0"
-triton = { version = "0.2.0", package = "neptune-triton", default-features=false, features=["opencl"] }
 neptune = { path = "../", features=["gpu"] }


### PR DESCRIPTION
Running bindgen at build time will burden all downstream users with an annoying dependency on clang, so use a new neptune-triton version which avoids this. This also means we need to avoid building the GPU code at all on MacOS. This PR is a bit of a hack, but it does allow running tests on MacOS with the gpu flag enabled. Actually using GPU on MacOS remains unsupported for now.