### PR TITLE
fix GPU memory leak

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ byteorder = "1"
 ff = { version = "0.2.1", package = "fff" }
 generic-array = "0.13.2"
 paired = "0.19.0"
-triton = { version = "0.2.1", package = "neptune-triton", default-features=false, features=["opencl"], optional=true }
+triton = { version = "0.2.2", package = "neptune-triton", default-features=false, features=["opencl"], optional=true }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/gbench/Cargo.toml
+++ b/gbench/Cargo.toml
@@ -15,5 +15,5 @@ env_logger = "0.7.1"
 ff = { version = "0.2.1", package = "fff" }
 generic-array = "0.13.2"
 log = "0.4.8"
-paired = "0.18.0"
+paired = "0.19.0"
 neptune = { path = "../", features=["gpu"] }

--- a/gbench/src/bin/gbench.rs
+++ b/gbench/src/bin/gbench.rs
@@ -91,7 +91,8 @@ fn bench_column_building(
 fn main() -> Result<(), Error> {
     env_logger::init();
 
-    let kib = 1024 * 1024 * 4;
+    let kib = 1024 * 1024 * 4; // 4GiB
+                               // let kib = 1024 * 512; // 512MiB
     let bytes = kib * 1024;
     let leaves = bytes / 32;
     let max_column_batch_size = 400000;
@@ -102,12 +103,17 @@ fn main() -> Result<(), Error> {
     info!("max column batch size: {}", max_column_batch_size);
     info!("max tree batch size: {}", max_tree_batch_size);
 
-    bench_column_building(
-        Some(BatcherType::GPU),
-        leaves,
-        max_column_batch_size,
-        max_tree_batch_size,
-    );
+    for i in 0..3 {
+        println!("--> Run {}", i);
+        bench_column_building(
+            Some(BatcherType::GPU),
+            leaves,
+            max_column_batch_size,
+            max_tree_batch_size,
+        );
+    }
     info!("end");
+    // Leave time to verify GPU memory usage goes to zero before exiting.
+    std::thread::sleep(std::time::Duration::from_millis(15000));
     Ok(())
 }

--- a/src/batch_hasher.rs
+++ b/src/batch_hasher.rs
@@ -19,7 +19,7 @@ where
     A: Arity<Fr>,
 {
     #[cfg(not(target_os = "macos"))]
-    GPU(GPUBatchHasher<A>),
+    GPU(GPUBatchHasher<'a, A>),
     #[cfg(target_os = "macos")]
     GPU(NoGPUBatchHasher<A>),
     CPU(SimplePoseidonBatchHasher<'a, A>),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 #![allow(dead_code)]
+#[macro_use]
+extern crate lazy_static;
 
 pub use crate::poseidon::{Arity, Poseidon};
 use crate::round_constants::generate_constants;

--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -252,6 +252,7 @@ where
     pub fn set_preimage(&mut self, preimage: &[E::Fr]) {
         self.reset();
         self.elements[1..].copy_from_slice(&preimage);
+        self.pos = self.elements.len();
     }
 
     /// Restore the initial state


### PR DESCRIPTION
This PR fixes an observed GPU memory leak and preemptively addresses one not observed.

- Modify gbench to run multiple times to reproduce the observed leak: memory would increase on each run until OOM error.
- Address this problem by (allocating only a single lazy static `FutharkContext` and share it between `BatchHasher`s. This allows Futhark's memory management to function as designed.
- Modify gbench to pause after completion to observe whether memory returns to zero. It did not previously do so, which impinges on memory available for the next process to use the GPU.
- Address this problem by calling `futhark_context_clear_caches()` whenever a `BatchHasher` is dropped. This ensures all memory we have freed is released on the GPU.