### PR TITLE
Support rows_to_discard when building trees.

### DIFF
--- a/gbench/src/bin/gbench.rs
+++ b/gbench/src/bin/gbench.rs
@@ -23,6 +23,7 @@ fn bench_column_building(
         leaves,
         max_column_batch_size,
         max_tree_batch_size,
+        0,
     )
     .unwrap();
     info!("ColumnTreeBuilder created");
@@ -62,7 +63,7 @@ fn bench_column_building(
         .collect();
 
     info!("adding final column batch and building tree");
-    let res = builder.add_final_columns(final_columns.as_slice()).unwrap();
+    let (_, res) = builder.add_final_columns(final_columns.as_slice()).unwrap();
     info!("end commitment");
     let elapsed = start.elapsed();
     info!("commitment time: {:?}", elapsed);
@@ -73,7 +74,7 @@ fn bench_column_building(
     let computed_root = res[res.len() - 1];
 
     let expected_root = builder.compute_uniform_tree_root(final_columns[0]).unwrap();
-    let expected_size = builder.tree_size();
+    let expected_size = builder.tree_size(0);
 
     assert_eq!(
         expected_size,

--- a/gbench/src/bin/gbench.rs
+++ b/gbench/src/bin/gbench.rs
@@ -23,7 +23,6 @@ fn bench_column_building(
         leaves,
         max_column_batch_size,
         max_tree_batch_size,
-        0,
     )
     .unwrap();
     info!("ColumnTreeBuilder created");
@@ -74,7 +73,7 @@ fn bench_column_building(
     let computed_root = res[res.len() - 1];
 
     let expected_root = builder.compute_uniform_tree_root(final_columns[0]).unwrap();
-    let expected_size = builder.tree_size(0);
+    let expected_size = builder.tree_size();
 
     assert_eq!(
         expected_size,

--- a/src/batch_hasher.rs
+++ b/src/batch_hasher.rs
@@ -5,7 +5,7 @@ use generic_array::GenericArray;
 use paired::bls12_381::Fr;
 use std::marker::PhantomData;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum BatcherType {
     GPU,
     CPU,
@@ -68,20 +68,6 @@ where
         }
     }
 
-    fn tree_leaf_count(&self) -> Option<usize> {
-        match self {
-            Batcher::GPU(batcher) => batcher.tree_leaf_count(),
-            Batcher::CPU(batcher) => batcher.tree_leaf_count(),
-        }
-    }
-
-    fn build_tree(&mut self, leaves: &[Fr]) -> Result<Vec<Fr>, Error> {
-        match self {
-            Batcher::GPU(batcher) => batcher.build_tree(leaves),
-            Batcher::CPU(batcher) => batcher.build_tree(leaves),
-        }
-    }
-
     fn max_batch_size(&self) -> usize {
         match self {
             Batcher::GPU(batcher) => batcher.max_batch_size(),
@@ -99,14 +85,6 @@ where
     A: Arity<Fr>,
 {
     fn hash(&mut self, _preimages: &[GenericArray<Fr, A>]) -> Result<Vec<Fr>, Error> {
-        unimplemented!();
-    }
-
-    fn tree_leaf_count(&self) -> Option<usize> {
-        unimplemented!();
-    }
-
-    fn build_tree(&mut self, _leaves: &[Fr]) -> Result<Vec<Fr>, Error> {
         unimplemented!();
     }
 

--- a/src/column_tree_builder.rs
+++ b/src/column_tree_builder.rs
@@ -110,7 +110,6 @@ where
         leaf_count: usize,
         max_column_batch_size: usize,
         max_tree_batch_size: usize,
-        rows_to_discard: usize,
     ) -> Result<Self, Error> {
         let builder = Self {
             leaf_count,
@@ -122,19 +121,14 @@ where
             } else {
                 None
             },
-            tree_builder: TreeBuilder::<TreeArity>::new(
-                t,
-                leaf_count,
-                max_tree_batch_size,
-                rows_to_discard,
-            )?,
+            tree_builder: TreeBuilder::<TreeArity>::new(t, leaf_count, max_tree_batch_size, 0)?,
         };
 
         Ok(builder)
     }
 
-    pub fn tree_size(&self, rows_to_discard: usize) -> usize {
-        self.tree_builder.tree_size(rows_to_discard)
+    pub fn tree_size(&self) -> usize {
+        self.tree_builder.tree_size(0)
     }
 
     // Compute root of tree composed of all identical columns. For use in checking correctness of GPU column tree-building
@@ -179,54 +173,51 @@ mod tests {
     ) {
         let batch_size = leaves / num_batches;
 
-        for rows_to_discard in 0..3 {
-            let mut builder = ColumnTreeBuilder::<U11, U8>::new(
-                batcher_type,
-                leaves,
-                max_column_batch_size,
-                max_tree_batch_size,
-                rows_to_discard,
-            )
-            .unwrap();
+        let mut builder = ColumnTreeBuilder::<U11, U8>::new(
+            batcher_type,
+            leaves,
+            max_column_batch_size,
+            max_tree_batch_size,
+        )
+        .unwrap();
 
-            // Simplify computing the expected root.
-            let constant_element = Fr::zero();
-            let constant_column = GenericArray::<Fr, U11>::generate(|_| constant_element);
+        // Simplify computing the expected root.
+        let constant_element = Fr::zero();
+        let constant_column = GenericArray::<Fr, U11>::generate(|_| constant_element);
 
-            let max_batch_size = if let Some(batcher) = &builder.column_batcher {
-                batcher.max_batch_size()
-            } else {
-                leaves
-            };
+        let max_batch_size = if let Some(batcher) = &builder.column_batcher {
+            batcher.max_batch_size()
+        } else {
+            leaves
+        };
 
-            let effective_batch_size = usize::min(batch_size, max_batch_size);
+        let effective_batch_size = usize::min(batch_size, max_batch_size);
 
-            let mut total_columns = 0;
-            while total_columns + effective_batch_size < leaves {
-                let columns: Vec<GenericArray<Fr, U11>> =
-                    (0..effective_batch_size).map(|_| constant_column).collect();
+        let mut total_columns = 0;
+        while total_columns + effective_batch_size < leaves {
+            let columns: Vec<GenericArray<Fr, U11>> =
+                (0..effective_batch_size).map(|_| constant_column).collect();
 
-                let _ = builder.add_columns(columns.as_slice()).unwrap();
-                total_columns += columns.len();
-            }
-
-            let final_columns: Vec<_> = (0..leaves - total_columns)
-                .map(|_| GenericArray::<Fr, U11>::generate(|_| constant_element))
-                .collect();
-
-            let (base, res) = builder.add_final_columns(final_columns.as_slice()).unwrap();
-
-            let column_hash =
-                Poseidon::new_with_preimage(&constant_column, &builder.column_constants).hash();
-            assert!(base.iter().all(|x| *x == column_hash));
-
-            let computed_root = res[res.len() - 1];
-
-            let expected_root = builder.compute_uniform_tree_root(final_columns[0]).unwrap();
-            let expected_size = builder.tree_builder.tree_size(0);
-
-            assert_eq!(expected_size, res.len());
-            assert_eq!(expected_root, computed_root);
+            let _ = builder.add_columns(columns.as_slice()).unwrap();
+            total_columns += columns.len();
         }
+
+        let final_columns: Vec<_> = (0..leaves - total_columns)
+            .map(|_| GenericArray::<Fr, U11>::generate(|_| constant_element))
+            .collect();
+
+        let (base, res) = builder.add_final_columns(final_columns.as_slice()).unwrap();
+
+        let column_hash =
+            Poseidon::new_with_preimage(&constant_column, &builder.column_constants).hash();
+        assert!(base.iter().all(|x| *x == column_hash));
+
+        let computed_root = res[res.len() - 1];
+
+        let expected_root = builder.compute_uniform_tree_root(final_columns[0]).unwrap();
+        let expected_size = builder.tree_builder.tree_size(0);
+
+        assert_eq!(expected_size, res.len());
+        assert_eq!(expected_root, computed_root);
     }
 }

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -117,26 +117,9 @@ where
     /// Hash a batch of `A`-sized preimages.
     fn hash(&mut self, preimages: &[GenericArray<Fr, A>]) -> Result<Vec<Fr>, Error> {
         let mut ctx = self.ctx.lock().unwrap();
-        let (res, state) = self.state.hash(&mut ctx, preimages)?; //FIXME
-        std::mem::replace(&mut self.state, state);
+        let (res, state) = self.state.hash(&mut ctx, preimages)?;
+        self.state = state;
         Ok(res)
-    }
-
-    fn tree_leaf_count(&self) -> Option<usize> {
-        match self.tree_builder_state {
-            Some(_) => Some(1 << 21), // Leaves for 64MiB tree. TODO: be more general.
-            None => None,
-        }
-    }
-
-    /// Build a 64MiB tree on the GPU.
-    fn build_tree(&mut self, leaves: &[Fr]) -> Result<Vec<Fr>, Error> {
-        let mut ctx = self.ctx.lock().unwrap();
-        let state = self
-            .tree_builder_state
-            .as_ref()
-            .expect("Tried to build without state.");
-        build_tree8_64m(&mut ctx, state, leaves)
     }
 
     fn max_batch_size(&self) -> usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,18 +63,6 @@ where
         Ok(target_slice.copy_from_slice(self.hash(preimages)?.as_slice()))
     }
 
-    /// How many leaves must be provided as input to the supported tree builder, intended for building a final small tree
-    /// rather than require repeated batches of dwindling size at the top of a tree whose rows are built in batches.
-    fn tree_leaf_count(&self) -> Option<usize> {
-        None
-    }
-
-    /// Build a merkle tree from provided leaves in a single call to the GPU.
-    /// Leaf count must match the value returned by `self.tree_leaf_count()`.
-    fn build_tree(&mut self, _leaves: &[Scalar]) -> Result<Vec<Scalar>, Error> {
-        unimplemented!();
-    }
-
     /// `max_batch_size` is advisory. Implenters of `BatchHasher` should ensure that up to the returned max hashes can
     /// be safely performed on the target GPU (currently 2080Ti). The max returned should represent a safe batch size
     /// optimized for performance.

--- a/src/tree_builder.rs
+++ b/src/tree_builder.rs
@@ -253,7 +253,7 @@ mod tests {
     #[test]
     fn test_tree_builder() {
         // 16KiB tree has 512 leaves.
-        test_tree_builder_aux(None, 1024, 32, 512, 512);
+        test_tree_builder_aux(None, 512, 32, 512, 512);
         test_tree_builder_aux(Some(BatcherType::CPU), 512, 32, 512, 512);
 
         #[cfg(all(feature = "gpu", not(target_os = "macos")))]


### PR DESCRIPTION
This PR adds support for `rows_to_discard`, which changes the general tree-building interface to return both the base row and the retained tree rows. The base row can be ignored by callers who don't need it because it was an input in the first place. In the case of the ColumnTreeBuilder, the base row is calculated and needs to be returned.

---
TODO:
 - [x] Also return computed base row from `ColumnTreeBuilder`, since this was *not* part of its input.
 - [x] FIXME: hold onto and use previous row before discarding.
 - [x] Add tests and make sure they pass.