### PR TITLE
improve support for strengthened poseidon

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ byteorder = "1"
 ff = { version = "0.2.1", package = "fff" }
 generic-array = "0.13.2"
 paired = "0.19.0"
-triton = { version = "0.2.2", package = "neptune-triton", default-features=false, features=["opencl"], optional=true }
+triton = { version = "1.0.0", package = "neptune-triton", default-features=false, features=["opencl"], optional=true }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/benches/hash.rs
+++ b/benches/hash.rs
@@ -66,7 +66,7 @@ where
         BenchmarkId::new("Poseidon hash", "Generated scalars"),
         &scalars,
         |b, s| {
-            let constants = PoseidonConstants::new();
+            let constants = PoseidonConstants::new_with_strength(Strength::Standard);
             let mut h = Poseidon::<Bls12, A>::new(&constants);
             b.iter(|| {
                 h.reset();
@@ -86,7 +86,7 @@ where
         BenchmarkId::new("Poseidon hash optimized", "Generated scalars"),
         &scalars,
         |b, s| {
-            let constants = PoseidonConstants::new();
+            let constants = PoseidonConstants::new_with_strength(Strength::Standard);
             let mut h = Poseidon::<Bls12, A>::new(&constants);
             b.iter(|| {
                 h.reset();
@@ -109,7 +109,7 @@ where
         ),
         &scalars,
         |b, s| {
-            let constants = PoseidonConstants::new_strengthened();
+            let constants = PoseidonConstants::new_with_strength(Strength::Strengthened);
             let mut h = Poseidon::<Bls12, A>::new(&constants);
             b.iter(|| {
                 h.reset();

--- a/benches/synthesis.rs
+++ b/benches/synthesis.rs
@@ -37,7 +37,7 @@ impl<A: Arity<Fr>> Circuit<Bls12> for BenchCircuit<A> {
                     AllocatedNum::alloc(cs.namespace(|| format!("data {}", i)), || Ok(fr)).unwrap()
                 })
                 .collect::<Vec<_>>();
-            let out = poseidon_hash(&mut cs, data, &constants).expect("poseidon hashing failed");
+            let _ = poseidon_hash(&mut cs, data, &constants).expect("poseidon hashing failed");
         }
         Ok(())
     }
@@ -51,7 +51,7 @@ where
 
     let mut num_hashes = 1;
 
-    for i in 0..4 {
+    for _ in 0..4 {
         group.bench_with_input(
             BenchmarkId::new(
                 "Poseidon Synthesis",

--- a/src/batch_hasher.rs
+++ b/src/batch_hasher.rs
@@ -1,6 +1,6 @@
 use crate::error::Error;
 use crate::poseidon::SimplePoseidonBatchHasher;
-use crate::{Arity, BatchHasher};
+use crate::{Arity, BatchHasher, Strength, DEFAULT_STRENGTH};
 use generic_array::GenericArray;
 use paired::bls12_381::Fr;
 use std::marker::PhantomData;
@@ -36,23 +36,27 @@ where
         }
     }
 
-    #[cfg(all(feature = "gpu", not(target_os = "macos")))]
     pub(crate) fn new(t: &BatcherType, max_batch_size: usize) -> Result<Self, Error> {
-        match t {
-            BatcherType::GPU => Ok(Batcher::GPU(GPUBatchHasher::<A>::new(max_batch_size)?)),
-
-            BatcherType::CPU => Ok(Batcher::CPU(SimplePoseidonBatchHasher::<A>::new(
-                max_batch_size,
-            )?)),
-        }
+        Self::new_with_strength(DEFAULT_STRENGTH, t, max_batch_size)
     }
-    #[cfg(not(all(feature = "gpu", not(target_os = "macos"))))]
-    pub(crate) fn new(t: &BatcherType, max_batch_size: usize) -> Result<Self, Error> {
+
+    pub(crate) fn new_with_strength(
+        strength: Strength,
+        t: &BatcherType,
+        max_batch_size: usize,
+    ) -> Result<Self, Error> {
         match t {
-            BatcherType::GPU => Err(Error::Other("GPU not configured".to_string())),
-            BatcherType::CPU => Ok(Batcher::CPU(SimplePoseidonBatchHasher::<A>::new(
+            #[cfg(all(feature = "gpu", target_os = "macos"))]
+            BatcherType::GPU => panic!("GPU unimplemented on macos"),
+            #[cfg(all(feature = "gpu", not(target_os = "macos")))]
+            BatcherType::GPU => Ok(Batcher::GPU(GPUBatchHasher::<A>::new_with_strength(
+                strength,
                 max_batch_size,
             )?)),
+
+            BatcherType::CPU => Ok(Batcher::CPU(
+                SimplePoseidonBatchHasher::<A>::new_with_strength(strength, max_batch_size)?,
+            )),
         }
     }
 }

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -567,7 +567,7 @@ mod tests {
     use super::*;
     use crate::poseidon::HashMode;
     use crate::test::TestConstraintSystem;
-    use crate::{scalar_from_u64, Poseidon};
+    use crate::{scalar_from_u64, Poseidon, Strength};
     use bellperson::ConstraintSystem;
     use generic_array::typenum;
     use paired::bls12_381::{Bls12, Fr};
@@ -576,33 +576,29 @@ mod tests {
 
     #[test]
     fn test_poseidon_hash() {
-        test_poseidon_hash_aux::<typenum::U2>(false, 314);
-        test_poseidon_hash_aux::<typenum::U4>(false, 380);
-        test_poseidon_hash_aux::<typenum::U8>(false, 508);
-        test_poseidon_hash_aux::<typenum::U16>(false, 764);
-        test_poseidon_hash_aux::<typenum::U24>(false, 1012);
-        test_poseidon_hash_aux::<typenum::U36>(false, 1388);
+        test_poseidon_hash_aux::<typenum::U2>(Strength::Standard, 314);
+        test_poseidon_hash_aux::<typenum::U4>(Strength::Standard, 380);
+        test_poseidon_hash_aux::<typenum::U8>(Strength::Standard, 508);
+        test_poseidon_hash_aux::<typenum::U16>(Strength::Standard, 764);
+        test_poseidon_hash_aux::<typenum::U24>(Strength::Standard, 1012);
+        test_poseidon_hash_aux::<typenum::U36>(Strength::Standard, 1388);
 
-        test_poseidon_hash_aux::<typenum::U2>(true, 370);
-        test_poseidon_hash_aux::<typenum::U4>(true, 436);
-        test_poseidon_hash_aux::<typenum::U8>(true, 568);
-        test_poseidon_hash_aux::<typenum::U16>(true, 824);
-        test_poseidon_hash_aux::<typenum::U24>(true, 1072);
-        test_poseidon_hash_aux::<typenum::U36>(true, 1448);
+        test_poseidon_hash_aux::<typenum::U2>(Strength::Strengthened, 370);
+        test_poseidon_hash_aux::<typenum::U4>(Strength::Strengthened, 436);
+        test_poseidon_hash_aux::<typenum::U8>(Strength::Strengthened, 568);
+        test_poseidon_hash_aux::<typenum::U16>(Strength::Strengthened, 824);
+        test_poseidon_hash_aux::<typenum::U24>(Strength::Strengthened, 1072);
+        test_poseidon_hash_aux::<typenum::U36>(Strength::Strengthened, 1448);
     }
 
-    fn test_poseidon_hash_aux<A>(strengthened: bool, expected_constraints: usize)
+    fn test_poseidon_hash_aux<A>(strength: Strength, expected_constraints: usize)
     where
         A: Arity<<Bls12 as Engine>::Fr>,
     {
         let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
         let mut cs = TestConstraintSystem::<Bls12>::new();
         let arity = A::to_usize();
-        let constants = if strengthened {
-            PoseidonConstants::<Bls12, A>::new_strengthened()
-        } else {
-            PoseidonConstants::<Bls12, A>::new()
-        };
+        let constants = PoseidonConstants::<Bls12, A>::new_with_strength(strength);
 
         let expected_constraints_calculated = {
             let width = 1 + arity;

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -1,6 +1,6 @@
 use crate::error::Error;
 use crate::poseidon::PoseidonConstants;
-use crate::{Arity, BatchHasher};
+use crate::{Arity, BatchHasher, Strength, DEFAULT_STRENGTH};
 use ff::{PrimeField, PrimeFieldDecodingError};
 use generic_array::{typenum, ArrayLength, GenericArray};
 use paired::bls12_381::{Bls12, Fr, FrRepr};
@@ -14,6 +14,11 @@ use typenum::{U11, U2, U8};
 type P2State = triton::FutharkOpaqueP2State;
 type P8State = triton::FutharkOpaqueP8State;
 type P11State = triton::FutharkOpaqueP11State;
+
+type S2State = triton::FutharkOpaqueS2State;
+type S8State = triton::FutharkOpaqueS8State;
+type S11State = triton::FutharkOpaqueS11State;
+
 pub(crate) type T864MState = triton::FutharkOpaqueT864MState;
 
 lazy_static! {
@@ -25,17 +30,26 @@ enum BatcherState {
     Arity2(P2State),
     Arity8(P8State),
     Arity11(P11State),
+    Arity2s(S2State),
+    Arity8s(S8State),
+    Arity11s(S11State),
 }
 
 impl BatcherState {
     /// Create a new state for use in batch hashing preimages of `Arity` elements.
     /// State is an opaque pointer supplied to the corresponding GPU entry point when processing a batch.
     fn new<A: Arity<Fr>>(ctx: &Mutex<FutharkContext>) -> Result<Self, Error> {
+        Self::new_with_strength::<A>(ctx, DEFAULT_STRENGTH)
+    }
+    fn new_with_strength<A: Arity<Fr>>(
+        ctx: &Mutex<FutharkContext>,
+        strength: Strength,
+    ) -> Result<Self, Error> {
         let mut ctx = ctx.lock().unwrap();
         Ok(match A::to_usize() {
-            size if size == 2 => BatcherState::Arity2(init_hash2(&mut ctx)?),
-            size if size == 8 => BatcherState::Arity8(init_hash8(&mut ctx)?),
-            size if size == 11 => BatcherState::Arity11(init_hash11(&mut ctx)?),
+            size if size == 2 => init_hash2(&mut ctx, strength)?,
+            size if size == 8 => init_hash8(&mut ctx, strength)?,
+            size if size == 11 => init_hash11(&mut ctx, strength)?,
             _ => panic!("unsupported arity: {}", A::to_usize()),
         })
     }
@@ -62,6 +76,18 @@ impl BatcherState {
                 let (res, state) = mbatch_hash11(ctx, state, preimages)?;
                 Ok((res, BatcherState::Arity11(state)))
             }
+            BatcherState::Arity2s(state) => {
+                let (res, state) = mbatch_hash2s(ctx, state, preimages)?;
+                Ok((res, BatcherState::Arity2s(state)))
+            }
+            BatcherState::Arity8s(state) => {
+                let (res, state) = mbatch_hash8s(ctx, state, preimages)?;
+                Ok((res, BatcherState::Arity8s(state)))
+            }
+            BatcherState::Arity11s(state) => {
+                let (res, state) = mbatch_hash11s(ctx, state, preimages)?;
+                Ok((res, BatcherState::Arity11s(state)))
+            }
         }
     }
 }
@@ -82,19 +108,19 @@ where
 {
     /// Create a new `GPUBatchHasher` and initialize it with state corresponding with its `A`.
     pub(crate) fn new(max_batch_size: usize) -> Result<Self, Error> {
+        Self::new_with_strength(DEFAULT_STRENGTH, max_batch_size)
+    }
+
+    /// Create a new `GPUBatchHasher` and initialize it with state corresponding with its `A`.
+    pub(crate) fn new_with_strength(
+        strength: Strength,
+        max_batch_size: usize,
+    ) -> Result<Self, Error> {
         let ctx = &*FUTHARK_CONTEXT;
         Ok(Self {
             ctx,
-            state: BatcherState::new::<A>(ctx)?,
+            state: BatcherState::new_with_strength::<A>(ctx, strength)?,
             tree_builder_state: None,
-            // Uncomment the following to build 64M trees.
-            // However, in practice this doesn't add noticeable speed and does use more memory.
-            // Leave the mechanism in as basis for further future experimentation, for now.
-            // if A::to_usize() == 8 {
-            //     Some(init_tree8_64m(&mut ctx)?)
-            // } else {
-            //     None
-            // },
             max_batch_size,
             _a: PhantomData::<A>,
         })
@@ -321,83 +347,99 @@ fn as_u64s<U: ArrayLength<Fr>>(vec: &[GenericArray<Fr, U>]) -> Vec<u64> {
     safely
 }
 
-fn init_hash2(ctx: &mut FutharkContext) -> Result<P2State, Error> {
-    let constants = GPUConstants(PoseidonConstants::<Bls12, U2>::new());
-    let state = ctx
-        .init2(
-            constants.arity_tag(&ctx)?,
-            constants.round_keys(&ctx)?,
-            constants.mds_matrix(&ctx)?,
-            constants.pre_sparse_matrix(&ctx)?,
-            constants.sparse_matrixes(&ctx)?,
-        )
-        .map_err(|e| Error::GPUError(format!("{:?}", e)))?;
-
-    Ok(state)
+fn init_hash2(ctx: &mut FutharkContext, strength: Strength) -> Result<BatcherState, Error> {
+    let constants = GPUConstants(PoseidonConstants::<Bls12, U2>::new_with_strength(strength));
+    match strength {
+        Strength::Standard => {
+            let state = ctx
+                .init2(
+                    constants.arity_tag(&ctx)?,
+                    constants.round_keys(&ctx)?,
+                    constants.mds_matrix(&ctx)?,
+                    constants.pre_sparse_matrix(&ctx)?,
+                    constants.sparse_matrixes(&ctx)?,
+                )
+                .map_err(|e| Error::GPUError(format!("{:?}", e)))?;
+            Ok(BatcherState::Arity2(state))
+        }
+        Strength::Strengthened => {
+            let state = ctx
+                .init2s(
+                    constants.arity_tag(&ctx)?,
+                    constants.round_keys(&ctx)?,
+                    constants.mds_matrix(&ctx)?,
+                    constants.pre_sparse_matrix(&ctx)?,
+                    constants.sparse_matrixes(&ctx)?,
+                )
+                .map_err(|e| Error::GPUError(format!("{:?}", e)))?;
+            Ok(BatcherState::Arity2s(state))
+        }
+    }
 }
 
-fn init_hash8(ctx: &mut FutharkContext) -> Result<P8State, Error> {
-    let constants = GPUConstants(PoseidonConstants::<Bls12, U8>::new());
-    let state = ctx
-        .init8(
-            constants.arity_tag(&ctx)?,
-            constants.round_keys(&ctx)?,
-            constants.mds_matrix(&ctx)?,
-            constants.pre_sparse_matrix(&ctx)?,
-            constants.sparse_matrixes(&ctx)?,
-        )
-        .map_err(|e| Error::GPUError(format!("{:?}", e)))?;
+fn init_hash8(ctx: &mut FutharkContext, strength: Strength) -> Result<BatcherState, Error> {
+    let constants = GPUConstants(PoseidonConstants::<Bls12, U8>::new_with_strength(strength));
+    match strength {
+        Strength::Standard => {
+            let state = ctx
+                .init8(
+                    constants.arity_tag(&ctx)?,
+                    constants.round_keys(&ctx)?,
+                    constants.mds_matrix(&ctx)?,
+                    constants.pre_sparse_matrix(&ctx)?,
+                    constants.sparse_matrixes(&ctx)?,
+                )
+                .map_err(|e| Error::GPUError(format!("{:?}", e)))?;
 
-    Ok(state)
+            Ok(BatcherState::Arity8(state))
+        }
+        Strength::Strengthened => {
+            let state = ctx
+                .init8s(
+                    constants.arity_tag(&ctx)?,
+                    constants.round_keys(&ctx)?,
+                    constants.mds_matrix(&ctx)?,
+                    constants.pre_sparse_matrix(&ctx)?,
+                    constants.sparse_matrixes(&ctx)?,
+                )
+                .map_err(|e| Error::GPUError(format!("{:?}", e)))?;
+
+            Ok(BatcherState::Arity8s(state))
+        }
+    }
 }
 
-fn init_hash11(ctx: &mut FutharkContext) -> Result<P11State, Error> {
-    let constants = GPUConstants(PoseidonConstants::<Bls12, U11>::new());
-    let state = ctx
-        .init11(
-            constants.arity_tag(&ctx)?,
-            constants.round_keys(&ctx)?,
-            constants.mds_matrix(&ctx)?,
-            constants.pre_sparse_matrix(&ctx)?,
-            constants.sparse_matrixes(&ctx)?,
-        )
-        .map_err(|e| Error::GPUError(format!("{:?}", e)))?;
+fn init_hash11(ctx: &mut FutharkContext, strength: Strength) -> Result<BatcherState, Error> {
+    let constants = GPUConstants(PoseidonConstants::<Bls12, U11>::new_with_strength(strength));
 
-    Ok(state)
-}
+    match strength {
+        Strength::Standard => {
+            let state = ctx
+                .init11(
+                    constants.arity_tag(&ctx)?,
+                    constants.round_keys(&ctx)?,
+                    constants.mds_matrix(&ctx)?,
+                    constants.pre_sparse_matrix(&ctx)?,
+                    constants.sparse_matrixes(&ctx)?,
+                )
+                .map_err(|e| Error::GPUError(format!("{:?}", e)))?;
 
-pub(crate) fn init_tree8_64m(ctx: &mut FutharkContext) -> Result<T864MState, Error> {
-    let constants = GPUConstants(PoseidonConstants::<Bls12, U8>::new());
-    let state = ctx
-        .init_t8_64m(
-            constants.arity_tag(&ctx)?,
-            constants.round_keys(&ctx)?,
-            constants.mds_matrix(&ctx)?,
-            constants.pre_sparse_matrix(&ctx)?,
-            constants.sparse_matrixes(&ctx)?,
-        )
-        .map_err(|e| Error::GPUError(format!("{:?}", e)))?;
+            Ok(BatcherState::Arity11(state))
+        }
+        Strength::Strengthened => {
+            let state = ctx
+                .init11s(
+                    constants.arity_tag(&ctx)?,
+                    constants.round_keys(&ctx)?,
+                    constants.mds_matrix(&ctx)?,
+                    constants.pre_sparse_matrix(&ctx)?,
+                    constants.sparse_matrixes(&ctx)?,
+                )
+                .map_err(|e| Error::GPUError(format!("{:?}", e)))?;
 
-    Ok(state)
-}
-
-pub(crate) fn build_tree8_64m(
-    ctx: &mut FutharkContext,
-    state: &T864MState,
-    leaves: &[Fr],
-) -> Result<Vec<Fr>, Error> {
-    let u64_leaves = frs_as_mont_u64s(leaves);
-    let input = Array_u64_1d::from_vec(*ctx, &u64_leaves, &[u64_leaves.len() as i64, 1])
-        .map_err(|_| Error::Other("could not convert".to_string()))?;
-
-    let res = ctx
-        .build_tree8_64m(state, input)
-        .map_err(|e| Error::GPUError(format!("{:?}", e)))?;
-
-    let (vec, _shape) = res.to_vec();
-    let frs = unpack_fr_array_from_monts(vec.as_slice())?;
-
-    Ok(frs.to_vec())
+            Ok(BatcherState::Arity11s(state))
+        }
+    }
 }
 
 fn mbatch_hash2<A>(
@@ -469,6 +511,75 @@ where
     Ok((frs.to_vec(), state))
 }
 
+fn mbatch_hash2s<A>(
+    ctx: &mut FutharkContext,
+    state: &mut S2State,
+    preimages: &[GenericArray<Fr, A>],
+) -> Result<(Vec<Fr>, S2State), Error>
+where
+    A: Arity<Fr>,
+{
+    assert_eq!(2, A::to_usize());
+    let flat_preimages = as_mont_u64s(preimages);
+    let input = Array_u64_1d::from_vec(*ctx, &flat_preimages, &[flat_preimages.len() as i64, 1])
+        .map_err(|_| Error::Other("could not convert".to_string()))?;
+
+    let (res, state) = ctx
+        .mbatch_hash2s(state, input)
+        .map_err(|e| Error::GPUError(format!("{:?}", e)))?;
+
+    let (vec, _shape) = res.to_vec();
+    let frs = unpack_fr_array_from_monts(vec.as_slice())?;
+
+    Ok((frs.to_vec(), state))
+}
+
+fn mbatch_hash8s<A>(
+    ctx: &mut FutharkContext,
+    state: &S8State,
+    preimages: &[GenericArray<Fr, A>],
+) -> Result<(Vec<Fr>, S8State), Error>
+where
+    A: Arity<Fr>,
+{
+    assert_eq!(8, A::to_usize());
+    let flat_preimages = as_mont_u64s(preimages);
+    let input = Array_u64_1d::from_vec(*ctx, &flat_preimages, &[flat_preimages.len() as i64, 1])
+        .map_err(|_| Error::Other("could not convert".to_string()))?;
+
+    let (res, state) = ctx
+        .mbatch_hash8s(state, input)
+        .map_err(|e| Error::GPUError(format!("{:?}", e)))?;
+
+    let (vec, _shape) = res.to_vec();
+    let frs = unpack_fr_array_from_monts(vec.as_slice())?;
+
+    Ok((frs.to_vec(), state))
+}
+
+fn mbatch_hash11s<A>(
+    ctx: &mut FutharkContext,
+    state: &S11State,
+    preimages: &[GenericArray<Fr, A>],
+) -> Result<(Vec<Fr>, S11State), Error>
+where
+    A: Arity<Fr>,
+{
+    assert_eq!(11, A::to_usize());
+    let flat_preimages = as_mont_u64s(preimages);
+    let input = Array_u64_1d::from_vec(*ctx, &flat_preimages, &[flat_preimages.len() as i64, 1])
+        .map_err(|_| Error::Other("could not convert".to_string()))?;
+
+    let (res, state) = ctx
+        .mbatch_hash11s(state, input)
+        .map_err(|e| Error::GPUError(format!("{:?}", e)))?;
+
+    let (vec, _shape) = res.to_vec();
+    let frs = unpack_fr_array_from_monts(vec.as_slice())?;
+
+    Ok((frs.to_vec(), state))
+}
+
 fn u64_vec<'a, U: ArrayLength<Fr>>(vec: &'a [GenericArray<Fr, U>]) -> Vec<u64> {
     vec![0; vec.len() * U::to_usize() * std::mem::size_of::<Fr>()]
 }
@@ -477,6 +588,7 @@ fn u64_vec<'a, U: ArrayLength<Fr>>(vec: &'a [GenericArray<Fr, U>]) -> Vec<u64> {
 #[cfg(all(feature = "gpu", not(target_os = "macos")))]
 mod tests {
     use super::*;
+    use crate::gpu::BatcherState;
     use crate::poseidon::{Poseidon, SimplePoseidonBatchHasher};
     use crate::BatchHasher;
     use ff::{Field, ScalarEngine};
@@ -488,18 +600,56 @@ mod tests {
     fn test_mbatch_hash2() {
         let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
         let mut ctx = FutharkContext::new();
-        let mut state = init_hash2(&mut ctx).unwrap();
+        let mut state =
+            if let BatcherState::Arity2(s) = init_hash2(&mut ctx, Strength::Standard).unwrap() {
+                s
+            } else {
+                panic!("expected Arity2");
+            };
         let batch_size = 100;
-        let arity = 2;
 
-        let mut gpu_hasher = GPUBatchHasher::<U2>::new(batch_size).unwrap();
-        let mut simple_hasher = SimplePoseidonBatchHasher::<U2>::new(batch_size).unwrap();
+        let mut gpu_hasher =
+            GPUBatchHasher::<U2>::new_with_strength(Strength::Standard, batch_size).unwrap();
+        let mut simple_hasher =
+            SimplePoseidonBatchHasher::<U2>::new_with_strength(Strength::Standard, batch_size)
+                .unwrap();
 
         let preimages = (0..batch_size)
             .map(|_| GenericArray::<Fr, U2>::generate(|_| Fr::random(&mut rng)))
             .collect::<Vec<_>>();
 
-        let (hashes, state) = mbatch_hash2(&mut ctx, &mut state, preimages.as_slice()).unwrap();
+        let (hashes, _) = mbatch_hash2(&mut ctx, &mut state, preimages.as_slice()).unwrap();
+        let gpu_hashes = gpu_hasher.hash(&preimages).unwrap();
+        let expected_hashes: Vec<_> = simple_hasher.hash(&preimages).unwrap();
+
+        assert_eq!(expected_hashes, hashes);
+        assert_eq!(expected_hashes, gpu_hashes);
+    }
+
+    #[test]
+    fn test_mbatch_hash2s() {
+        let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
+        let mut ctx = FutharkContext::new();
+        let mut state = if let BatcherState::Arity2s(s) =
+            init_hash2(&mut ctx, Strength::Strengthened).unwrap()
+        {
+            s
+        } else {
+            panic!("expected Arity2s");
+        };
+        let batch_size = 100;
+
+        let mut gpu_hasher =
+            GPUBatchHasher::<U2>::new_with_strength(Strength::Strengthened, batch_size).unwrap();
+        let mut simple_hasher =
+            SimplePoseidonBatchHasher::<U2>::new_with_strength(Strength::Strengthened, batch_size)
+                .unwrap();
+
+        let preimages = (0..batch_size)
+            .map(|_| GenericArray::<Fr, U2>::generate(|_| Fr::random(&mut rng)))
+            .collect::<Vec<_>>();
+
+        let (hashes, _) = mbatch_hash2s(&mut ctx, &mut state, preimages.as_slice()).unwrap();
         let gpu_hashes = gpu_hasher.hash(&preimages).unwrap();
         let expected_hashes: Vec<_> = simple_hasher.hash(&preimages).unwrap();
 
@@ -511,46 +661,121 @@ mod tests {
     fn test_mbatch_hash8() {
         let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
         let mut ctx = FutharkContext::new();
-        let mut state = init_hash8(&mut ctx).unwrap();
+        let mut state =
+            if let BatcherState::Arity8(s) = init_hash8(&mut ctx, Strength::Standard).unwrap() {
+                s
+            } else {
+                panic!("expected Arity8");
+            };
         let batch_size = 100;
-        let arity = 2;
 
-        let mut gpu_hasher = GPUBatchHasher::<U8>::new(batch_size).unwrap();
-        let mut simple_hasher = SimplePoseidonBatchHasher::<U8>::new(batch_size).unwrap();
+        let mut gpu_hasher =
+            GPUBatchHasher::<U8>::new_with_strength(Strength::Standard, batch_size).unwrap();
+        let mut simple_hasher =
+            SimplePoseidonBatchHasher::<U8>::new_with_strength(Strength::Standard, batch_size)
+                .unwrap();
 
         let preimages = (0..batch_size)
             .map(|_| GenericArray::<Fr, U8>::generate(|_| Fr::random(&mut rng)))
             .collect::<Vec<_>>();
 
-        let (hashes, state) = mbatch_hash8(&mut ctx, &mut state, preimages.as_slice()).unwrap();
+        let (hashes, _) = mbatch_hash8(&mut ctx, &mut state, preimages.as_slice()).unwrap();
         let gpu_hashes = gpu_hasher.hash(&preimages).unwrap();
         let expected_hashes: Vec<_> = simple_hasher.hash(&preimages).unwrap();
 
         assert_eq!(expected_hashes, hashes);
         assert_eq!(expected_hashes, gpu_hashes);
+    }
 
-        #[test]
-        fn test_mbatch_hash11() {
-            let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
-            let mut ctx = FutharkContext::new();
-            let mut state = init_hash11(&mut ctx).unwrap();
-            let batch_size = 100;
-            let arity = 2;
+    #[test]
+    fn test_mbatch_hash8s() {
+        let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
+        let mut ctx = FutharkContext::new();
+        let mut state = if let BatcherState::Arity8s(s) =
+            init_hash8(&mut ctx, Strength::Strengthened).unwrap()
+        {
+            s
+        } else {
+            panic!("expected Arity8s");
+        };
+        let batch_size = 100;
 
-            let mut gpu_hasher = GPUBatchHasher::<U11>::new(batch_size).unwrap();
-            let mut simple_hasher = SimplePoseidonBatchHasher::<U11>::new(batch_size).unwrap();
+        let mut gpu_hasher =
+            GPUBatchHasher::<U8>::new_with_strength(Strength::Strengthened, batch_size).unwrap();
+        let mut simple_hasher =
+            SimplePoseidonBatchHasher::<U8>::new_with_strength(Strength::Strengthened, batch_size)
+                .unwrap();
 
-            let preimages = (0..batch_size)
-                .map(|_| GenericArray::<Fr, U11>::generate(|_| Fr::random(&mut rng)))
-                .collect::<Vec<_>>();
+        let preimages = (0..batch_size)
+            .map(|_| GenericArray::<Fr, U8>::generate(|_| Fr::random(&mut rng)))
+            .collect::<Vec<_>>();
 
-            let (hashes, state) =
-                mbatch_hash11(&mut ctx, &mut state, preimages.as_slice()).unwrap();
-            let gpu_hashes = gpu_hasher.hash(&preimages).unwrap();
-            let expected_hashes: Vec<_> = simple_hasher.hash(&preimages).unwrap();
+        let (hashes, _) = mbatch_hash8s(&mut ctx, &mut state, preimages.as_slice()).unwrap();
+        let gpu_hashes = gpu_hasher.hash(&preimages).unwrap();
+        let expected_hashes: Vec<_> = simple_hasher.hash(&preimages).unwrap();
 
-            assert_eq!(expected_hashes, hashes);
-            assert_eq!(expected_hashes, gpu_hashes);
-        }
+        assert_eq!(expected_hashes, hashes);
+        assert_eq!(expected_hashes, gpu_hashes);
+    }
+
+    #[test]
+    fn test_mbatch_hash11() {
+        let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
+        let mut ctx = FutharkContext::new();
+        let mut state =
+            if let BatcherState::Arity11(s) = init_hash11(&mut ctx, Strength::Standard).unwrap() {
+                s
+            } else {
+                panic!("expected Arity11");
+            };
+        let batch_size = 100;
+
+        let mut gpu_hasher =
+            GPUBatchHasher::<U11>::new_with_strength(Strength::Standard, batch_size).unwrap();
+        let mut simple_hasher =
+            SimplePoseidonBatchHasher::<U11>::new_with_strength(Strength::Standard, batch_size)
+                .unwrap();
+
+        let preimages = (0..batch_size)
+            .map(|_| GenericArray::<Fr, U11>::generate(|_| Fr::random(&mut rng)))
+            .collect::<Vec<_>>();
+
+        let (hashes, _) = mbatch_hash11(&mut ctx, &mut state, preimages.as_slice()).unwrap();
+        let gpu_hashes = gpu_hasher.hash(&preimages).unwrap();
+        let expected_hashes: Vec<_> = simple_hasher.hash(&preimages).unwrap();
+
+        assert_eq!(expected_hashes, hashes);
+        assert_eq!(expected_hashes, gpu_hashes);
+    }
+
+    #[test]
+    fn test_mbatch_hash11s() {
+        let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
+        let mut ctx = FutharkContext::new();
+        let mut state = if let BatcherState::Arity11s(s) =
+            init_hash11(&mut ctx, Strength::Strengthened).unwrap()
+        {
+            s
+        } else {
+            panic!("expected Arity11s");
+        };
+        let batch_size = 100;
+
+        let mut gpu_hasher =
+            GPUBatchHasher::<U11>::new_with_strength(Strength::Strengthened, batch_size).unwrap();
+        let mut simple_hasher =
+            SimplePoseidonBatchHasher::<U11>::new_with_strength(Strength::Strengthened, batch_size)
+                .unwrap();
+
+        let preimages = (0..batch_size)
+            .map(|_| GenericArray::<Fr, U11>::generate(|_| Fr::random(&mut rng)))
+            .collect::<Vec<_>>();
+
+        let (hashes, _) = mbatch_hash11s(&mut ctx, &mut state, preimages.as_slice()).unwrap();
+        let gpu_hashes = gpu_hasher.hash(&preimages).unwrap();
+        let expected_hashes: Vec<_> = simple_hasher.hash(&preimages).unwrap();
+
+        assert_eq!(expected_hashes, hashes);
+        assert_eq!(expected_hashes, gpu_hashes);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,14 @@ pub(crate) const TEST_SEED: [u8; 16] = [
     0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc, 0xe5,
 ];
 
+#[derive(Copy, Clone, Debug)]
+pub enum Strength {
+    Standard,
+    Strengthened,
+}
+
+pub(crate) const DEFAULT_STRENGTH: Strength = Strength::Standard;
+
 pub trait BatchHasher<A>
 where
     A: Arity<Scalar>,
@@ -109,11 +117,10 @@ fn round_numbers_strengthened(arity: usize) -> (usize, usize) {
     (full_round, strengthened_partial_rounds)
 }
 
-pub fn round_numbers(arity: usize, strengthened: bool) -> (usize, usize) {
-    if strengthened {
-        round_numbers_strengthened(arity)
-    } else {
-        round_numbers_base(arity)
+pub fn round_numbers(arity: usize, strength: &Strength) -> (usize, usize) {
+    match strength {
+        Strength::Standard => round_numbers_base(arity),
+        Strength::Strengthened => round_numbers_strengthened(arity),
     }
 }
 
@@ -130,10 +137,10 @@ pub fn scalar_from_u64s(parts: [u64; 4]) -> Scalar {
 const SBOX: u8 = 1; // x^5
 const FIELD: u8 = 1; // Gf(p)
 
-fn round_constants<E: ScalarEngine>(arity: usize, strengthened: bool) -> Vec<E::Fr> {
+fn round_constants<E: ScalarEngine>(arity: usize, strength: &Strength) -> Vec<E::Fr> {
     let t = arity + 1;
 
-    let (full_rounds, partial_rounds) = round_numbers(arity, strengthened);
+    let (full_rounds, partial_rounds) = round_numbers(arity, strength);
 
     let r_f = full_rounds as u16;
     let r_p = partial_rounds as u16;


### PR DESCRIPTION
This PR ~makes strengthened Poseidon the default and~ adds GPU support for ~that variant~ strengthened Poseidon.

Since this work began, we have decided to revert to standard strength by default. That makes this branch name out of date, but I am leaving it in order to preserve the PR history.

  - [x] Update Cargo dependency after releasing a new version of `neptune-triton` (which itself depends on a new version of `genfut`).