### PR TITLE
Update neptune-triton and pairing.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ byteorder = "1"
 ff = { version = "0.2.1", package = "fff" }
 generic-array = "0.13.2"
 paired = "0.20.0"
-triton = { version = "1.0.0", package = "neptune-triton", default-features=false, features=["opencl"], optional=true }
+triton = { version = "1.1.0", package = "neptune-triton", default-features = false, features = ["opencl"], optional = true }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/gbench/Cargo.toml
+++ b/gbench/Cargo.toml
@@ -15,5 +15,5 @@ env_logger = "0.7.1"
 ff = { version = "0.2.1", package = "fff" }
 generic-array = "0.13.2"
 log = "0.4.8"
-paired = "0.19.0"
+paired = "0.20.0"
 neptune = { path = "../", features=["gpu"] }


### PR DESCRIPTION
This PR uses the latest neptune-trition (https://github.com/filecoin-project/neptune-triton/pull/8)  fixes the outdated gbench dependencies.