### PR TITLE
feat: allow overwriting default gpu via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Programming Language](https://futhark-lang.org/).
 
 At the time of the 1.0.0 release, Neptune on RTX 2080Ti GPU can build 8-ary Merkle trees for 4GiB of input in 16 seconds.
 
+## Environment variables
+
+ - `NEPTUNE_DEFAULT_GPU=<bus-id>` allows you to select the default GPU that tree-builder is going to run on given its bus-id.
+
+(Bus-id is a decimal integer that can be found through `nvidia-smi`, `rocm-smi`, `lspci` and etc.)
+
 ## Future Work
 
 The following are likely areas of future work:

--- a/gbench/README.md
+++ b/gbench/README.md
@@ -1,0 +1,9 @@
+# gbench
+
+Benchmarking tool for Neptune.
+
+## Environment variables
+
+ - `NEPTUNE_GBENCH_GPUS=<bus-id1>,<bus-id2>,...` allows you to select the GPUs you want to run gbench on given a comma-separated list of bus-ids.
+ 
+(Bus-id is a decimal integer that can be found through `nvidia-smi`, `rocm-smi`, `lspci` and etc.)


### PR DESCRIPTION
Usage:
`NEPTUNE_DEFAULT_GPU=<bus-id>`