### PR TITLE
Avoid compiling any OpenCl on macos.

### DIFF
--- a/src/batch_hasher.rs
+++ b/src/batch_hasher.rs
@@ -1,3 +1,4 @@
+#[cfg(all(feature = "gpu", not(target_os = "macos")))]
 use crate::cl;
 use crate::error::Error;
 use crate::poseidon::SimplePoseidonBatchHasher;
@@ -8,7 +9,10 @@ use std::marker::PhantomData;
 
 #[derive(Clone, Copy, Debug)]
 pub enum BatcherType {
+    #[cfg(all(feature = "gpu", not(target_os = "macos")))]
     CustomGPU(cl::GPUSelector),
+    #[cfg(all(feature = "gpu", target_os = "macos"))]
+    CustomGPU(()),
     GPU,
     CPU,
 }

--- a/src/column_tree_builder.rs
+++ b/src/column_tree_builder.rs
@@ -1,4 +1,5 @@
 use crate::batch_hasher::{Batcher, BatcherType};
+#[cfg(all(feature = "gpu", not(target_os = "macos")))]
 use crate::cl::GPUSelector;
 use crate::error::Error;
 use crate::poseidon::{Poseidon, PoseidonConstants};

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "gpu")]
+#[cfg(all(feature = "gpu", not(target_os = "macos")))]
 use crate::cl;
 use std::{error, fmt};
 
@@ -11,13 +11,13 @@ pub enum Error {
     IndexOutOfBounds,
     /// The provided leaf was not found in the tree
     GPUError(String),
-    #[cfg(feature = "gpu")]
+    #[cfg(all(feature = "gpu", not(target_os = "macos")))]
     ClError(cl::ClError),
     DecodingError,
     Other(String),
 }
 
-#[cfg(feature = "gpu")]
+#[cfg(all(feature = "gpu", not(target_os = "macos")))]
 impl From<cl::ClError> for Error {
     fn from(e: cl::ClError) -> Self {
         Self::ClError(e)
@@ -35,7 +35,7 @@ impl fmt::Display for Error {
             ),
             Error::IndexOutOfBounds => write!(f, "The referenced index is outs of bounds."),
             Error::GPUError(s) => write!(f, "GPU Error: {}", s),
-            #[cfg(feature = "gpu")]
+            #[cfg(all(feature = "gpu", not(target_os = "macos")))]
             Error::ClError(e) => write!(f, "OpenCL Error: {}", e),
             Error::DecodingError => write!(f, "PrimeFieldDecodingError"),
             Error::Other(s) => write!(f, "{}", s),

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -1,3 +1,4 @@
+#[cfg(all(feature = "gpu", not(target_os = "macos")))]
 use crate::cl;
 use crate::error::Error;
 use crate::poseidon::PoseidonConstants;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub mod column_tree_builder;
 #[cfg(feature = "gpu")]
 mod gpu;
 
-#[cfg(feature = "gpu")]
+#[cfg(all(feature = "gpu", not(target_os = "macos")))]
 pub mod cl;
 
 /// Batch Hasher

--- a/src/tree_builder.rs
+++ b/src/tree_builder.rs
@@ -1,4 +1,5 @@
 use crate::batch_hasher::{Batcher, BatcherType};
+#[cfg(all(feature = "gpu", not(target_os = "macos")))]
 use crate::cl::GPUSelector;
 use crate::error::Error;
 use crate::poseidon::{Poseidon, PoseidonConstants};


### PR DESCRIPTION
References to the OpenCl bindings cause downstream compile errors on macos.