### PR TITLE
[WIP] Revert content of v1.2.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ ff = { version = "0.2.1", package = "fff" }
 generic-array = "0.13.2"
 paired = "0.20.0"
 triton = { version = "1.1.0", package = "neptune-triton", default-features = false, features = ["opencl"], optional = true }
-log = "0.4.8"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/column_tree_builder.rs
+++ b/src/column_tree_builder.rs
@@ -1,6 +1,5 @@
 use crate::batch_hasher::{Batcher, BatcherType};
 use crate::error::Error;
-use crate::gpu::GPUSelector;
 use crate::poseidon::{Poseidon, PoseidonConstants};
 use crate::tree_builder::{TreeBuilder, TreeBuilderTrait};
 use crate::{Arity, BatchHasher};
@@ -22,7 +21,7 @@ where
     fn reset(&mut self);
 }
 
-pub struct ColumnTreeBuilder<ColumnArity, TreeArity>
+pub struct ColumnTreeBuilder<'a, ColumnArity, TreeArity>
 where
     ColumnArity: Arity<Fr>,
     TreeArity: Arity<Fr>,
@@ -32,12 +31,12 @@ where
     /// Index of the first unfilled datum.
     fill_index: usize,
     column_constants: PoseidonConstants<Bls12, ColumnArity>,
-    pub column_batcher: Option<Batcher<ColumnArity>>,
-    tree_builder: TreeBuilder<TreeArity>,
+    pub column_batcher: Option<Batcher<'a, ColumnArity>>,
+    tree_builder: TreeBuilder<'a, TreeArity>,
 }
 
 impl<ColumnArity, TreeArity> ColumnTreeBuilderTrait<ColumnArity, TreeArity>
-    for ColumnTreeBuilder<ColumnArity, TreeArity>
+    for ColumnTreeBuilder<'_, ColumnArity, TreeArity>
 where
     ColumnArity: Arity<Fr>,
     TreeArity: Arity<Fr>,
@@ -101,7 +100,7 @@ fn as_generic_arrays<'a, A: Arity<Fr>>(vec: &'a [Fr]) -> &'a [GenericArray<Fr, A
     }
 }
 
-impl<ColumnArity, TreeArity> ColumnTreeBuilder<ColumnArity, TreeArity>
+impl<ColumnArity, TreeArity> ColumnTreeBuilder<'_, ColumnArity, TreeArity>
 where
     ColumnArity: Arity<Fr>,
     TreeArity: Arity<Fr>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,3 @@
-#[cfg(all(feature = "gpu", not(target_os = "macos")))]
-use crate::cl;
 use std::{error, fmt};
 
 #[derive(Debug, Clone)]
@@ -11,17 +9,8 @@ pub enum Error {
     IndexOutOfBounds,
     /// The provided leaf was not found in the tree
     GPUError(String),
-    #[cfg(all(feature = "gpu", not(target_os = "macos")))]
-    ClError(cl::ClError),
     DecodingError,
     Other(String),
-}
-
-#[cfg(all(feature = "gpu", not(target_os = "macos")))]
-impl From<cl::ClError> for Error {
-    fn from(e: cl::ClError) -> Self {
-        Self::ClError(e)
-    }
 }
 
 impl error::Error for Error {}
@@ -35,8 +24,6 @@ impl fmt::Display for Error {
             ),
             Error::IndexOutOfBounds => write!(f, "The referenced index is outs of bounds."),
             Error::GPUError(s) => write!(f, "GPU Error: {}", s),
-            #[cfg(all(feature = "gpu", not(target_os = "macos")))]
-            Error::ClError(e) => write!(f, "OpenCL Error: {}", e),
             Error::DecodingError => write!(f, "PrimeFieldDecodingError"),
             Error::Other(s) => write!(f, "{}", s),
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,7 +15,6 @@ pub enum Error {
     Other(String),
 }
 
-
 #[cfg(feature = "gpu")]
 impl From<triton::Error> for Error {
     fn from(e: triton::Error) -> Self {

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -25,7 +25,8 @@ type S11State = triton::FutharkOpaqueS11State;
 pub(crate) type T864MState = triton::FutharkOpaqueT864MState;
 
 lazy_static! {
-    pub static ref FUTHARK_CONTEXT: Mutex<FutharkContext> = Mutex::new(FutharkContext::new());
+    pub static ref FUTHARK_CONTEXT: Mutex<FutharkContext> =
+        Mutex::new(FutharkContext::new().unwrap());
 }
 
 /// Container to hold the state corresponding to each supported arity.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,12 +37,6 @@ pub mod column_tree_builder;
 #[cfg(feature = "gpu")]
 mod gpu;
 
-#[cfg(feature = "gpu")]
-pub use gpu::GPUSelector;
-
-#[cfg(all(feature = "gpu", not(target_os = "macos")))]
-mod cl;
-
 /// Batch Hasher
 #[cfg(feature = "gpu")]
 pub mod batch_hasher;

--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -530,17 +530,18 @@ where
 }
 
 #[derive(Debug)]
-pub struct SimplePoseidonBatchHasher<A>
+pub struct SimplePoseidonBatchHasher<'a, A>
 where
     A: Arity<bls12_381::Fr>,
 {
     constants: PoseidonConstants<Bls12, A>,
     max_batch_size: usize,
+    _s: PhantomData<Poseidon<'a, Bls12, A>>,
 }
 
-impl<A> SimplePoseidonBatchHasher<A>
+impl<'a, A> SimplePoseidonBatchHasher<'a, A>
 where
-    A: Arity<bls12_381::Fr>,
+    A: 'a + Arity<bls12_381::Fr>,
 {
     pub(crate) fn new(max_batch_size: usize) -> Result<Self, Error> {
         Self::new_with_strength(DEFAULT_STRENGTH, max_batch_size)
@@ -553,12 +554,13 @@ where
         Ok(Self {
             constants: PoseidonConstants::<Bls12, A>::new_with_strength(strength),
             max_batch_size,
+            _s: PhantomData::<Poseidon<'a, Bls12, A>>,
         })
     }
 }
-impl<A> BatchHasher<A> for SimplePoseidonBatchHasher<A>
+impl<'a, A> BatchHasher<A> for SimplePoseidonBatchHasher<'a, A>
 where
-    A: Arity<bls12_381::Fr>,
+    A: 'a + Arity<bls12_381::Fr>,
 {
     fn hash(
         &mut self,

--- a/src/tree_builder.rs
+++ b/src/tree_builder.rs
@@ -1,6 +1,5 @@
 use crate::batch_hasher::{Batcher, BatcherType};
 use crate::error::Error;
-use crate::gpu::GPUSelector;
 use crate::poseidon::{Poseidon, PoseidonConstants};
 use crate::{Arity, BatchHasher};
 use ff::Field;
@@ -17,7 +16,7 @@ where
     fn reset(&mut self);
 }
 
-pub struct TreeBuilder<TreeArity>
+pub struct TreeBuilder<'a, TreeArity>
 where
     TreeArity: Arity<Fr>,
 {
@@ -26,11 +25,11 @@ where
     /// Index of the first unfilled datum.
     fill_index: usize,
     tree_constants: PoseidonConstants<Bls12, TreeArity>,
-    tree_batcher: Option<Batcher<TreeArity>>,
+    tree_batcher: Option<Batcher<'a, TreeArity>>,
     rows_to_discard: usize,
 }
 
-impl<TreeArity> TreeBuilderTrait<TreeArity> for TreeBuilder<TreeArity>
+impl<TreeArity> TreeBuilderTrait<TreeArity> for TreeBuilder<'_, TreeArity>
 where
     TreeArity: Arity<Fr>,
 {
@@ -82,7 +81,7 @@ fn as_generic_arrays<'a, A: Arity<Fr>>(vec: &'a [Fr]) -> &'a [GenericArray<Fr, A
     }
 }
 
-impl<TreeArity> TreeBuilder<TreeArity>
+impl<TreeArity> TreeBuilder<'_, TreeArity>
 where
     TreeArity: Arity<Fr>,
 {


### PR DESCRIPTION
The content of v1.2.0 has caused problems downstream when tested in a branch. It has not yet been consumed by a `rust-fil-proofs` release. This PR reverts it so we can move forward with the `2.0` branch and safely consume it downstream.

After merging this, the plan is to release patch version v2.0.1, which should be fine since this contains no API-breaking changes.