### PR TITLE
Make GPUSelector accessible from gbench.

### DIFF
--- a/gbench/src/bin/gbench.rs
+++ b/gbench/src/bin/gbench.rs
@@ -115,7 +115,7 @@ fn main() -> Result<(), Error> {
         .map(|v| {
             v.split(",")
                 .map(|s| s.parse::<u32>().expect("Invalid Bus-Id number!"))
-                .map(|bus_id| BatcherType::CustomGPU(neptune::GPUSelector::BusId(bus_id)))
+                .map(|bus_id| BatcherType::CustomGPU(neptune::cl::GPUSelector::BusId(bus_id)))
                 .collect::<Vec<_>>()
         })
         .unwrap_or(vec![BatcherType::GPU]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub mod column_tree_builder;
 mod gpu;
 
 #[cfg(all(feature = "gpu", not(target_os = "macos")))]
-mod cl;
+pub mod cl;
 
 /// Batch Hasher
 #[cfg(feature = "gpu")]


### PR DESCRIPTION
`gbench` had gotten out of date and didn't compile. This PR fixes that.