### PR TITLE
Explicitly reuse FutharkContext in related Batchers.

### DIFF
--- a/gbench/src/bin/gbench.rs
+++ b/gbench/src/bin/gbench.rs
@@ -111,7 +111,8 @@ fn main() -> Result<(), Error> {
     info!("max tree batch size: {}", max_tree_batch_size);
 
     // Comma separated list of GPU bus-ids
-    let batcher_types = std::env::var("NEPTUNE_GBENCH_GPUS")
+    let gpus = std::env::var("NEPTUNE_GBENCH_GPUS");
+    let batcher_types = gpus
         .map(|v| {
             v.split(",")
                 .map(|s| s.parse::<u32>().expect("Invalid Bus-Id number!"))
@@ -119,7 +120,6 @@ fn main() -> Result<(), Error> {
                 .collect::<Vec<_>>()
         })
         .unwrap_or(vec![BatcherType::GPU]);
-
     let mut threads = Vec::new();
     for batcher_type in batcher_types {
         threads.push(thread::spawn(move || {
@@ -128,7 +128,7 @@ fn main() -> Result<(), Error> {
                 info!("{} --> Run {}", log_prefix, i);
                 bench_column_building(
                     &log_prefix,
-                    Some(batcher_type),
+                    Some(batcher_type.clone()),
                     leaves,
                     max_column_batch_size,
                     max_tree_batch_size,

--- a/src/batch_hasher.rs
+++ b/src/batch_hasher.rs
@@ -1,3 +1,6 @@
+use std::fmt::{self, Debug};
+use std::sync::{Arc, Mutex};
+
 #[cfg(all(feature = "gpu", not(target_os = "macos")))]
 use crate::cl;
 use crate::error::Error;
@@ -6,15 +9,29 @@ use crate::{Arity, BatchHasher, Strength, DEFAULT_STRENGTH};
 use generic_array::GenericArray;
 use paired::bls12_381::Fr;
 use std::marker::PhantomData;
+use triton::FutharkContext;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone)]
 pub enum BatcherType {
     #[cfg(all(feature = "gpu", not(target_os = "macos")))]
     CustomGPU(cl::GPUSelector),
     #[cfg(all(feature = "gpu", target_os = "macos"))]
     CustomGPU(()),
+    FromFutharkContext(Arc<Mutex<FutharkContext>>),
     GPU,
     CPU,
+}
+
+impl Debug for BatcherType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!("BatcherType::"))?;
+        match self {
+            BatcherType::FromFutharkContext(_) => f.write_fmt(format_args!("FromFutharkContext")),
+            BatcherType::CustomGPU(x) => f.write_fmt(format_args!("CustomGPU({:?})", x)),
+            BatcherType::CPU => f.write_fmt(format_args!("CPU")),
+            BatcherType::GPU => f.write_fmt(format_args!("GPU")),
+        }
+    }
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -53,15 +70,15 @@ where
     ) -> Result<Self, Error> {
         match t {
             #[cfg(all(feature = "gpu", target_os = "macos"))]
-            BatcherType::GPU => panic!("GPU unimplemented on macos"),
-            #[cfg(all(feature = "gpu", target_os = "macos"))]
-            BatcherType::CustomGPU(_) => panic!("GPU unimplemented on macos"),
+            BatcherType::GPU => unimplemented!("GPU unsupported on macos"),
             #[cfg(all(feature = "gpu", not(target_os = "macos")))]
             BatcherType::GPU => Ok(Batcher::GPU(GPUBatchHasher::<A>::new_with_strength(
                 cl::default_futhark_context()?,
                 strength,
                 max_batch_size,
             )?)),
+            #[cfg(all(feature = "gpu", target_os = "macos"))]
+            BatcherType::CustomGPU(_) => unimplemented!("GPU unsupported on macos"),
             #[cfg(all(feature = "gpu", not(target_os = "macos")))]
             BatcherType::CustomGPU(selector) => {
                 Ok(Batcher::GPU(GPUBatchHasher::<A>::new_with_strength(
@@ -70,10 +87,26 @@ where
                     max_batch_size,
                 )?))
             }
-
             BatcherType::CPU => Ok(Batcher::CPU(
                 SimplePoseidonBatchHasher::<A>::new_with_strength(strength, max_batch_size)?,
             )),
+            #[cfg(all(feature = "gpu", not(target_os = "macos")))]
+            BatcherType::FromFutharkContext(futhark_context) => {
+                Ok(Batcher::GPU(GPUBatchHasher::<A>::new_with_strength(
+                    futhark_context.clone(),
+                    strength,
+                    max_batch_size,
+                )?))
+            }
+            #[cfg(all(feature = "gpu", target_os = "macos"))]
+            BatcherType::FromFutharkContext(_) => unimplemented!("GPU unsupported on macos"),
+        }
+    }
+
+    pub(crate) fn futhark_context(&self) -> Option<Arc<Mutex<FutharkContext>>> {
+        match self {
+            Batcher::GPU(b) => Some(b.futhark_context()),
+            _ => None,
         }
     }
 }
@@ -111,5 +144,14 @@ where
 
     fn max_batch_size(&self) -> usize {
         unimplemented!();
+    }
+}
+
+impl<A> NoGPUBatchHasher<A>
+where
+    A: Arity<Fr>,
+{
+    fn futhark_context(&self) -> Arc<Mutex<FutharkContext>> {
+        unimplemented!()
     }
 }

--- a/src/cl.rs
+++ b/src/cl.rs
@@ -2,7 +2,7 @@ use log::*;
 use std::collections::HashMap;
 use std::fmt;
 use std::ptr;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock};
 use triton::bindings;
 use triton::FutharkContext;
 
@@ -19,8 +19,8 @@ struct cl_amd_device_topology {
 }
 
 lazy_static! {
-    pub static ref FUTHARK_CONTEXT_MAP: Mutex<HashMap<u32, Arc<Mutex<FutharkContext>>>> =
-        Mutex::new(HashMap::new());
+    pub static ref FUTHARK_CONTEXT_MAP: RwLock<HashMap<u32, Arc<Mutex<FutharkContext>>>> =
+        RwLock::new(HashMap::new());
 }
 
 #[derive(Debug, Clone)]
@@ -285,7 +285,8 @@ pub fn get_all_bus_ids() -> ClResult<Vec<u32>> {
 }
 
 pub fn futhark_context(selector: GPUSelector) -> ClResult<Arc<Mutex<FutharkContext>>> {
-    let mut map = FUTHARK_CONTEXT_MAP.lock().unwrap();
+    info!("getting context for ~{:?}", selector);
+    let mut map = FUTHARK_CONTEXT_MAP.write().unwrap();
     let bus_id = selector.get_bus_id()?;
     if !map.contains_key(&bus_id) {
         let device = get_device_by_bus_id(bus_id)?;

--- a/src/column_tree_builder.rs
+++ b/src/column_tree_builder.rs
@@ -113,17 +113,33 @@ where
         max_column_batch_size: usize,
         max_tree_batch_size: usize,
     ) -> Result<Self, Error> {
+        let column_batcher = match &t {
+            Some(t) => Some(Batcher::<ColumnArity>::new(t, max_column_batch_size)?),
+            None => None,
+        };
+
+        let tree_builder = match {
+            match &column_batcher {
+                Some(b) => b.futhark_context(),
+                None => None,
+            }
+        } {
+            Some(ctx) => TreeBuilder::<TreeArity>::new(
+                Some(BatcherType::FromFutharkContext(ctx)),
+                leaf_count,
+                max_tree_batch_size,
+                0,
+            )?,
+            None => TreeBuilder::<TreeArity>::new(t, leaf_count, max_tree_batch_size, 0)?,
+        };
+
         let builder = Self {
             leaf_count,
             data: vec![Fr::zero(); leaf_count],
             fill_index: 0,
             column_constants: PoseidonConstants::<Bls12, ColumnArity>::new(),
-            column_batcher: if let Some(t) = &t {
-                Some(Batcher::<ColumnArity>::new(t, max_column_batch_size)?)
-            } else {
-                None
-            },
-            tree_builder: TreeBuilder::<TreeArity>::new(t, leaf_count, max_tree_batch_size, 0)?,
+            column_batcher,
+            tree_builder,
         };
 
         Ok(builder)

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -128,6 +128,10 @@ where
             _a: PhantomData::<A>,
         })
     }
+
+    pub(crate) fn futhark_context(&self) -> Arc<Mutex<FutharkContext>> {
+        self.ctx.clone()
+    }
 }
 
 impl<A> Drop for GPUBatchHasher<A> {
@@ -602,13 +606,14 @@ mod tests {
     #[test]
     fn test_mbatch_hash2() {
         let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
-        let mut ctx = FutharkContext::new().unwrap();
-        let mut state =
-            if let BatcherState::Arity2(s) = init_hash2(&mut ctx, Strength::Standard).unwrap() {
-                s
-            } else {
-                panic!("expected Arity2");
-            };
+        let ctx = cl::default_futhark_context().unwrap();
+        let mut state = if let BatcherState::Arity2(s) =
+            init_hash2(&mut ctx.lock().unwrap(), Strength::Standard).unwrap()
+        {
+            s
+        } else {
+            panic!("expected Arity2");
+        };
         let batch_size = 100;
 
         let mut gpu_hasher = GPUBatchHasher::<U2>::new_with_strength(
@@ -625,7 +630,8 @@ mod tests {
             .map(|_| GenericArray::<Fr, U2>::generate(|_| Fr::random(&mut rng)))
             .collect::<Vec<_>>();
 
-        let (hashes, _) = mbatch_hash2(&mut ctx, &mut state, preimages.as_slice()).unwrap();
+        let (hashes, _) =
+            mbatch_hash2(&mut ctx.lock().unwrap(), &mut state, preimages.as_slice()).unwrap();
         let gpu_hashes = gpu_hasher.hash(&preimages).unwrap();
         let expected_hashes: Vec<_> = simple_hasher.hash(&preimages).unwrap();
 
@@ -636,9 +642,9 @@ mod tests {
     #[test]
     fn test_mbatch_hash2s() {
         let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
-        let mut ctx = FutharkContext::new().unwrap();
+        let ctx = cl::default_futhark_context().unwrap();
         let mut state = if let BatcherState::Arity2s(s) =
-            init_hash2(&mut ctx, Strength::Strengthened).unwrap()
+            init_hash2(&mut ctx.lock().unwrap(), Strength::Strengthened).unwrap()
         {
             s
         } else {
@@ -660,7 +666,8 @@ mod tests {
             .map(|_| GenericArray::<Fr, U2>::generate(|_| Fr::random(&mut rng)))
             .collect::<Vec<_>>();
 
-        let (hashes, _) = mbatch_hash2s(&mut ctx, &mut state, preimages.as_slice()).unwrap();
+        let (hashes, _) =
+            mbatch_hash2s(&mut ctx.lock().unwrap(), &mut state, preimages.as_slice()).unwrap();
         let gpu_hashes = gpu_hasher.hash(&preimages).unwrap();
         let expected_hashes: Vec<_> = simple_hasher.hash(&preimages).unwrap();
 
@@ -671,13 +678,14 @@ mod tests {
     #[test]
     fn test_mbatch_hash8() {
         let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
-        let mut ctx = FutharkContext::new().unwrap();
-        let mut state =
-            if let BatcherState::Arity8(s) = init_hash8(&mut ctx, Strength::Standard).unwrap() {
-                s
-            } else {
-                panic!("expected Arity8");
-            };
+        let ctx = cl::default_futhark_context().unwrap();
+        let mut state = if let BatcherState::Arity8(s) =
+            init_hash8(&mut ctx.lock().unwrap(), Strength::Standard).unwrap()
+        {
+            s
+        } else {
+            panic!("expected Arity8");
+        };
         let batch_size = 100;
 
         let mut gpu_hasher = GPUBatchHasher::<U8>::new_with_strength(
@@ -694,7 +702,8 @@ mod tests {
             .map(|_| GenericArray::<Fr, U8>::generate(|_| Fr::random(&mut rng)))
             .collect::<Vec<_>>();
 
-        let (hashes, _) = mbatch_hash8(&mut ctx, &mut state, preimages.as_slice()).unwrap();
+        let (hashes, _) =
+            mbatch_hash8(&mut ctx.lock().unwrap(), &mut state, preimages.as_slice()).unwrap();
         let gpu_hashes = gpu_hasher.hash(&preimages).unwrap();
         let expected_hashes: Vec<_> = simple_hasher.hash(&preimages).unwrap();
 
@@ -705,9 +714,9 @@ mod tests {
     #[test]
     fn test_mbatch_hash8s() {
         let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
-        let mut ctx = FutharkContext::new().unwrap();
+        let ctx = cl::default_futhark_context().unwrap();
         let mut state = if let BatcherState::Arity8s(s) =
-            init_hash8(&mut ctx, Strength::Strengthened).unwrap()
+            init_hash8(&mut ctx.lock().unwrap(), Strength::Strengthened).unwrap()
         {
             s
         } else {
@@ -729,7 +738,8 @@ mod tests {
             .map(|_| GenericArray::<Fr, U8>::generate(|_| Fr::random(&mut rng)))
             .collect::<Vec<_>>();
 
-        let (hashes, _) = mbatch_hash8s(&mut ctx, &mut state, preimages.as_slice()).unwrap();
+        let (hashes, _) =
+            mbatch_hash8s(&mut ctx.lock().unwrap(), &mut state, preimages.as_slice()).unwrap();
         let gpu_hashes = gpu_hasher.hash(&preimages).unwrap();
         let expected_hashes: Vec<_> = simple_hasher.hash(&preimages).unwrap();
 
@@ -740,13 +750,14 @@ mod tests {
     #[test]
     fn test_mbatch_hash11() {
         let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
-        let mut ctx = FutharkContext::new().unwrap();
-        let mut state =
-            if let BatcherState::Arity11(s) = init_hash11(&mut ctx, Strength::Standard).unwrap() {
-                s
-            } else {
-                panic!("expected Arity11");
-            };
+        let ctx = cl::default_futhark_context().unwrap();
+        let mut state = if let BatcherState::Arity11(s) =
+            init_hash11(&mut ctx.lock().unwrap(), Strength::Standard).unwrap()
+        {
+            s
+        } else {
+            panic!("expected Arity11");
+        };
         let batch_size = 100;
 
         let mut gpu_hasher = GPUBatchHasher::<U11>::new_with_strength(
@@ -763,7 +774,8 @@ mod tests {
             .map(|_| GenericArray::<Fr, U11>::generate(|_| Fr::random(&mut rng)))
             .collect::<Vec<_>>();
 
-        let (hashes, _) = mbatch_hash11(&mut ctx, &mut state, preimages.as_slice()).unwrap();
+        let (hashes, _) =
+            mbatch_hash11(&mut ctx.lock().unwrap(), &mut state, preimages.as_slice()).unwrap();
         let gpu_hashes = gpu_hasher.hash(&preimages).unwrap();
         let expected_hashes: Vec<_> = simple_hasher.hash(&preimages).unwrap();
 
@@ -774,9 +786,9 @@ mod tests {
     #[test]
     fn test_mbatch_hash11s() {
         let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
-        let mut ctx = FutharkContext::new().unwrap();
+        let ctx = cl::default_futhark_context().unwrap();
         let mut state = if let BatcherState::Arity11s(s) =
-            init_hash11(&mut ctx, Strength::Strengthened).unwrap()
+            init_hash11(&mut ctx.lock().unwrap(), Strength::Strengthened).unwrap()
         {
             s
         } else {
@@ -798,7 +810,8 @@ mod tests {
             .map(|_| GenericArray::<Fr, U11>::generate(|_| Fr::random(&mut rng)))
             .collect::<Vec<_>>();
 
-        let (hashes, _) = mbatch_hash11s(&mut ctx, &mut state, preimages.as_slice()).unwrap();
+        let (hashes, _) =
+            mbatch_hash11s(&mut ctx.lock().unwrap(), &mut state, preimages.as_slice()).unwrap();
         let gpu_hashes = gpu_hasher.hash(&preimages).unwrap();
         let expected_hashes: Vec<_> = simple_hasher.hash(&preimages).unwrap();
 
@@ -808,13 +821,14 @@ mod tests {
 
     fn test_mbatch_hash8_on_device(dev: Arc<Mutex<FutharkContext>>) {
         let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
-        let mut ctx = FutharkContext::new().unwrap();
-        let mut state =
-            if let BatcherState::Arity8(s) = init_hash8(&mut ctx, Strength::Standard).unwrap() {
-                s
-            } else {
-                panic!("expected Arity8");
-            };
+        let ctx = cl::default_futhark_context().unwrap();
+        let mut state = if let BatcherState::Arity8(s) =
+            init_hash8(&mut ctx.lock().unwrap(), Strength::Standard).unwrap()
+        {
+            s
+        } else {
+            panic!("expected Arity8");
+        };
         let batch_size = 100;
 
         let mut gpu_hasher =
@@ -827,7 +841,8 @@ mod tests {
             .map(|_| GenericArray::<Fr, U8>::generate(|_| Fr::random(&mut rng)))
             .collect::<Vec<_>>();
 
-        let (hashes, _) = mbatch_hash8(&mut ctx, &mut state, preimages.as_slice()).unwrap();
+        let (hashes, _) =
+            mbatch_hash8(&mut ctx.lock().unwrap(), &mut state, preimages.as_slice()).unwrap();
         let gpu_hashes = gpu_hasher.hash(&preimages).unwrap();
         let expected_hashes: Vec<_> = simple_hasher.hash(&preimages).unwrap();
 

--- a/src/tree_builder.rs
+++ b/src/tree_builder.rs
@@ -274,9 +274,13 @@ mod tests {
         let batch_size = leaves / num_batches;
 
         for rows_to_discard in 0..3 {
-            let mut builder =
-                TreeBuilder::<U8>::new(batcher_type, leaves, max_tree_batch_size, rows_to_discard)
-                    .unwrap();
+            let mut builder = TreeBuilder::<U8>::new(
+                batcher_type.clone(),
+                leaves,
+                max_tree_batch_size,
+                rows_to_discard,
+            )
+            .unwrap();
 
             // Simplify computing the expected root.
             let constant_element = Fr::zero();


### PR DESCRIPTION
Checking out a `FutharkContext` by `BusId` requires locking `FUTHARK_CONTEXT_MAP`. Since `ColumnTreeBuilder` requires two `BatchHashers`, each with a `FutharkContext`, creation was being interleaved such that if multiple were created in parallel (as in `gbench`), the first initiated was still blocked on initial context creation of the second.

This PR allows for explicit reuse of a single `FutharkContext`, avoiding this problem. It would be even better if context creation did not hold the Mutex — since it turns out that on some platforms (AMD…), this can be slow. However, the current fix addresses  the first immediate problem.