### PR TITLE
Refactor, moving device selection to rust-gpu-tools.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ byteorder = "1"
 ff = { version = "0.2.1", package = "fff" }
 generic-array = "0.14.4"
 log = "0.4.8"
+rust-gpu-tools = { version = "0.2.2", optional = true }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 triton = { version = "2.0.0", package = "neptune-triton", default-features = false, features = ["opencl"], optional = true }
@@ -45,7 +46,7 @@ codegen-units = 1
 
 [features]
 default = ["pairing"]
-gpu = ["triton"]
+gpu = ["triton", "rust-gpu-tools"]
 pairing = ["bellperson/pairing"]
 blst = ["bellperson/blst"]
 

--- a/gbench/Cargo.toml
+++ b/gbench/Cargo.toml
@@ -15,7 +15,8 @@ env_logger = "0.7.1"
 ff = { version = "0.2.1", package = "fff" }
 generic-array = "0.14.4"
 log = "0.4.8"
-neptune = { path = "../", default-features = false }
+neptune = { path = "../", default-features = false, features=["gpu"] }
+rust-gpu-tools = { version = "0.2.2" }
 
 [features]
 default = ["pairing", "gpu"]

--- a/gbench/src/main.rs
+++ b/gbench/src/main.rs
@@ -8,6 +8,7 @@ use neptune::batch_hasher::BatcherType;
 use neptune::column_tree_builder::{ColumnTreeBuilder, ColumnTreeBuilderTrait};
 use neptune::error::Error;
 use neptune::BatchHasher;
+use rust_gpu_tools::opencl::GPUSelector;
 use std::result::Result;
 use std::thread;
 use std::time::Instant;
@@ -116,7 +117,7 @@ fn main() -> Result<(), Error> {
         .map(|v| {
             v.split(",")
                 .map(|s| s.parse::<u32>().expect("Invalid Bus-Id number!"))
-                .map(|bus_id| BatcherType::CustomGPU(neptune::cl::GPUSelector::BusId(bus_id)))
+                .map(|bus_id| BatcherType::CustomGPU(GPUSelector::BusId(bus_id)))
                 .collect::<Vec<_>>()
         })
         .unwrap_or(vec![BatcherType::GPU]);

--- a/src/batch_hasher.rs
+++ b/src/batch_hasher.rs
@@ -9,13 +9,14 @@ use crate::poseidon::SimplePoseidonBatchHasher;
 use crate::{Arity, BatchHasher, Strength, DEFAULT_STRENGTH};
 use bellperson::bls::Fr;
 use generic_array::GenericArray;
+use rust_gpu_tools::opencl::GPUSelector;
 #[cfg(all(feature = "gpu", not(target_os = "macos")))]
 use triton::FutharkContext;
 
 #[derive(Clone)]
 pub enum BatcherType {
     #[cfg(all(feature = "gpu", not(target_os = "macos")))]
-    CustomGPU(cl::GPUSelector),
+    CustomGPU(GPUSelector),
     #[cfg(all(feature = "gpu", target_os = "macos"))]
     CustomGPU(()),
     #[cfg(all(feature = "gpu", not(target_os = "macos")))]

--- a/src/column_tree_builder.rs
+++ b/src/column_tree_builder.rs
@@ -1,6 +1,4 @@
 use crate::batch_hasher::{Batcher, BatcherType};
-#[cfg(all(feature = "gpu", not(target_os = "macos")))]
-use crate::cl::GPUSelector;
 use crate::error::Error;
 use crate::poseidon::{Poseidon, PoseidonConstants};
 use crate::tree_builder::{TreeBuilder, TreeBuilderTrait};
@@ -8,6 +6,8 @@ use crate::{Arity, BatchHasher};
 use bellperson::bls::{Bls12, Fr};
 use ff::Field;
 use generic_array::GenericArray;
+#[cfg(all(feature = "gpu", not(target_os = "macos")))]
+use rust_gpu_tools::opencl::GPUSelector;
 
 pub trait ColumnTreeBuilderTrait<ColumnArity, TreeArity>
 where

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -880,14 +880,4 @@ mod tests {
         assert_eq!(expected_hashes, hashes);
         assert_eq!(expected_hashes, gpu_hashes);
     }
-
-    #[test]
-    fn test_custom_gpus() {
-        let bus_ids = cl::get_all_bus_ids().unwrap();
-        for bus_id in bus_ids {
-            test_mbatch_hash8_on_device(
-                cl::futhark_context(cl::GPUSelector::BusId(bus_id)).unwrap(),
-            );
-        }
-    }
 }

--- a/src/tree_builder.rs
+++ b/src/tree_builder.rs
@@ -1,12 +1,12 @@
 use crate::batch_hasher::{Batcher, BatcherType};
-#[cfg(all(feature = "gpu", not(target_os = "macos")))]
-use crate::cl::GPUSelector;
 use crate::error::Error;
 use crate::poseidon::{Poseidon, PoseidonConstants};
 use crate::{Arity, BatchHasher};
 use bellperson::bls::{Bls12, Fr};
 use ff::Field;
 use generic_array::GenericArray;
+#[cfg(all(feature = "gpu", not(target_os = "macos")))]
+use rust_gpu_tools::opencl::GPUSelector;
 
 pub trait TreeBuilderTrait<TreeArity>
 where


### PR DESCRIPTION
This PR depends on https://github.com/filecoin-project/rust-gpu-tools/pull/24, which moves the `GPUSelector` implementation into `rust-gpu-tools`. Once that PR merges, this one can be finalized (removing the Git dependency).