### PR TITLE
Fix comment equation.

### DIFF
--- a/src/mds.rs
+++ b/src/mds.rs
@@ -244,7 +244,7 @@ mod tests {
             &matrix::mat_mul::<Bls12>(&m_inv, &m).unwrap()
         ));
 
-        // M' x M'' = I
+        // M' x M'' = M
         assert_eq!(
             m,
             matrix::mat_mul::<Bls12>(&m_prime, &m_double_prime).unwrap()


### PR DESCRIPTION
This just fixes a self-explanatory typo (`I` for `M`) in a comment's equation.