### PR TITLE
Update CHANGELOG for 2.6.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://book.async.rs/overview
 
 ## Unreleased
 
-## 2.5 - 2021-1-21
+## 2.6 - 2021-1-21
 - Pure OpenCL implementation of batch hashing. (https://github.com/filecoin-project/neptune/pull/78)
+
+## 2.5 [release commited but never published to crates.io, due to authentication glitch]
 
 ## 2.4.0 - 2020-11-17
 


### PR DESCRIPTION
When I released 2.5, it failed to publish to crates.io, and when I retried with `cargo release`, the minor version got bumped a second time. This PR updates the CHANGELOG to be in sync with the actual published version.