### PR TITLE
chore: improve Clippy on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,8 +78,6 @@ jobs:
       - run: rustup install $(cat rust-toolchain)
       - run: rustup default $(cat rust-toolchain)
       - run: rustup install nightly-2020-11-18
-      - run: rustup component add rustfmt-preview
-      - run: rustup component add clippy-preview
       - run: rustc --version
       - run: rm -rf .git
       - persist_to_workspace:
@@ -144,10 +142,10 @@ jobs:
       - run: sudo apt install -y ocl-icd-opencl-dev
       - run:
           name: Run cargo clippy (pairing)
-          command: cargo clippy --no-default-features --features pairing,gpu
+          command: cargo clippy --all-targets --no-default-features --features pairing,gpu -- -D warnings
       - run:
           name: Run cargo clippy (blst)
-          command: cargo clippy --no-default-features --features blst,gpu
+          command: cargo clippy --all-targets --no-default-features --features blst,gpu -- -D warnings
 
   build:
     executor: default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,27 +26,27 @@ commands:
       - *restore-workspace
       - *restore-cache
       - run:
-          name: Test (pairing) (<< parameters.target >>)
+          name: Test default features (pairing) (<< parameters.target >>)
           command: TARGET=<< parameters.target >> cargo test --release
           no_output_timeout: 5m
       - run:
           name: Test (blst) (<< parameters.target >>)
           command: TARGET=<< parameters.target >> cargo test --no-default-features --features blst --release  -- --test-threads=1
           no_output_timeout: 5m
+
       - run:
           name: Test (pairing, GPU) (<< parameters.target >>)
           command: TARGET=<< parameters.target >> cargo test --release --no-default-features --features pairing,gpu -- --test-threads=1
           no_output_timeout: 30m
-
       - run:
           name: Test (blst, GPU) (<< parameters.target >>)
           command: TARGET=<< parameters.target >> cargo test --release --no-default-features --features blst,gpu -- --test-threads=1
           no_output_timeout: 30m
+
       - run:
           name: Test (pairing, opencl) (<< parameters.target >>)
           command: TARGET=<< parameters.target >> cargo test --release --no-default-features --features pairing,opencl -- --test-threads=1
           no_output_timeout: 30m
-
       - run:
           name: Test (blst, opencl) (<< parameters.target >>)
           command: TARGET=<< parameters.target >> cargo test --release --no-default-features --features blst,opencl -- --test-threads=1
@@ -77,7 +77,6 @@ jobs:
       - run: cargo fetch
       - run: rustup install $(cat rust-toolchain)
       - run: rustup default $(cat rust-toolchain)
-      - run: rustup install nightly-2020-11-18
       - run: rustc --version
       - run: rm -rf .git
       - persist_to_workspace:
@@ -141,68 +140,25 @@ jobs:
       - run: apt-cache search opencl
       - run: sudo apt install -y ocl-icd-opencl-dev
       - run:
-          name: Run cargo clippy (pairing)
-          command: cargo clippy --all-targets --no-default-features --features pairing,gpu -- -D warnings
+          # gbench doesn't support running without GPU support, hence don't run Clippy on the whole workspace
+          name: Run cargo clippy (pairing), without gbench
+          command: cargo clippy --all-targets --no-default-features --features pairing -- -D warnings
       - run:
-          name: Run cargo clippy (blst)
-          command: cargo clippy --all-targets --no-default-features --features blst,gpu -- -D warnings
-
-  build:
-    executor: default
-    steps:
-      - *restore-workspace
-      - *restore-cache
-      - run: echo 'export PATH="$HOME:~/.cargo/bin:$PATH"' >> $BASH_ENV
-      - run: source $BASH_ENV
-      - run: sudo apt-get update -y
-      - run: apt-cache search opencl
-      - run: sudo apt install -y ocl-icd-opencl-dev
+          # gbench doesn't support running without GPU support, hence don't run Clippy on the whole workspace
+          name: Run cargo clippy (blst), without gbench
+          command: cargo clippy --all-targets --no-default-features --features blst -- -D warnings
       - run:
-          name: Run cargo release build (pairing)
-          command: cargo build --release --no-default-features --features pairing
+          name: Run cargo clippy (pairing, gpu)
+          command: cargo clippy --workspace --all-targets --no-default-features --features pairing,gpu -- -D warnings
       - run:
-          name: Run cargo release build (blst)
-          command: cargo build --release --no-default-features --features blst
+          name: Run cargo clippy (blst, gpu)
+          command: cargo clippy --workspace --all-targets --no-default-features --features blst,gpu -- -D warnings
       - run:
-          name: Run cargo release build (pairing, gpu)
-          command: cargo build --release --no-default-features --features pairing,gpu
+          name: Run cargo clippy (pairing, opencl)
+          command: cargo clippy --workspace --all-targets --no-default-features --features pairing,opencl -- -D warnings
       - run:
-          name: Run cargo release build (blst, gpu)
-          command: cargo build --release --no-default-features --features blst,gpu
-
-  build_gbench:
-    executor: default
-    steps:
-      - *restore-workspace
-      - *restore-cache
-      - run: echo 'export PATH="$HOME:~/.cargo/bin:$PATH"' >> $BASH_ENV
-      - run: source $BASH_ENV
-      - run: sudo apt-get update -y
-      - run: apt-cache search opencl
-      - run: sudo apt install -y ocl-icd-opencl-dev
-      - run:
-          name: Run cargo release build (pairing, gpu)
-          command: cargo +nightly-2020-11-18 build -Zpackage-features --release -p gbench --no-default-features --features pairing,gpu
-      - run:
-          name: Run cargo release build (blst, gpu)
-          command: cargo +nightly-2020-11-18 build -Zpackage-features --release -p gbench --no-default-features --features blst,gpu
-
-  benches:
-    executor: default
-    steps:
-      - *restore-workspace
-      - *restore-cache
-      - run: echo 'export PATH="$HOME:~/.cargo/bin:$PATH"' >> $BASH_ENV
-      - run: source $BASH_ENV
-      - run: sudo apt-get update -y
-      - run: apt-cache search opencl
-      - run: sudo apt install -y ocl-icd-opencl-dev
-      - run:
-          name: Run cargo build --benches (pairing)
-          command: cargo build --benches --no-default-features --features pairing --release
-      - run:
-          name: Run cargo build --benches (blst)
-          command: cargo build --benches --no-default-features --features blst --release
+          name: Run cargo clippy (blst, opencl)
+          command: cargo clippy --workspace --all-targets --no-default-features --features blst,opencl -- -D warnings
 
 workflows:
   version: 2.1
@@ -220,14 +176,5 @@ workflows:
           requires:
             - cargo_fetch
       - test_darwin:
-          requires:
-            - cargo_fetch
-      - build:
-          requires:
-            - cargo_fetch
-      - build_gbench:
-          requires:
-            - cargo_fetch
-      - benches:
           requires:
             - cargo_fetch

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["porcuquine <porcuquine@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/filecoin-project/neptune"
+resolver = "2"
 
 [dependencies]
 lazy_static = "1.4.0"

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -647,9 +647,7 @@ mod tests {
                 let s_box_constraints = 3 * s_boxes;
                 let mds_constraints =
                     (width * constants.full_rounds) + constants.partial_rounds - arity;
-                let total_constraints = arity_tag_constraints + s_box_constraints + mds_constraints;
-
-                total_constraints
+                arity_tag_constraints + s_box_constraints + mds_constraints
             };
             let mut i = 0;
 

--- a/src/mds.rs
+++ b/src/mds.rs
@@ -272,7 +272,7 @@ mod tests {
         let mut x = base.clone();
         x[0] = Fr::random(&mut rng);
 
-        let mut y = base.clone();
+        let mut y = base;
         y[0] = Fr::random(&mut rng);
 
         let qx = apply_matrix::<Bls12>(&m_prime, &x);
@@ -335,7 +335,7 @@ mod tests {
         let actual = sparse
             .iter()
             .zip(&round_keys)
-            .fold(initial.clone(), |mut acc, (m, rk)| {
+            .fold(initial, |mut acc, (m, rk)| {
                 acc = apply_matrix::<Bls12>(&m, &acc);
                 quintic_s_box::<Bls12>(&mut acc[0], None, Some(&rk));
                 acc

--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -665,15 +665,12 @@ mod tests {
         let mut p4 = Poseidon::<Bls12, A>::new(&constants);
 
         let test_arity = constants.arity();
-        let mut preimage = vec![Scalar::zero(); test_arity];
         for n in 0..test_arity {
             let scalar = scalar_from_u64::<Fr>(n as u64);
             p.input(scalar).unwrap();
             p2.input(scalar).unwrap();
             p3.input(scalar).unwrap();
             p4.input(scalar).unwrap();
-
-            preimage[n] = scalar;
         }
 
         let digest = p.hash();
@@ -798,11 +795,9 @@ mod tests {
         let constants = PoseidonConstants::<Bls12, U2>::new();
         let mut p = Poseidon::<Bls12, U2>::new(&constants);
         let test_arity = constants.arity();
-        let mut preimage = vec![Scalar::zero(); test_arity];
         for n in 0..test_arity {
             let scalar = scalar_from_u64::<Fr>(n as u64);
             p.input(scalar).unwrap();
-            preimage[n] = scalar;
         }
         let mut p2 = p.clone();
         let mut p3 = p.clone();

--- a/src/round_constants.rs
+++ b/src/round_constants.rs
@@ -217,7 +217,7 @@ mod tests {
         let path = Path::new("parameters/round_constants-1-1-255-9-8-57-73EDA753299D7D483339D80809A1D80553BDA402FFFE5BFEFFFFFFFF00000001.txt");
         let input = File::open(path).unwrap();
         let buffered = BufReader::new(input);
-        let line = buffered.lines().skip(8).next().unwrap().unwrap();
+        let line = buffered.lines().nth(8).unwrap().unwrap();
         let replaced = line.replace("'", "\"");
         let parsed: Vec<Value> = serde_json::from_str(&replaced).unwrap();
 

--- a/src/round_numbers.rs
+++ b/src/round_numbers.rs
@@ -119,13 +119,14 @@ mod tests {
         let lines: Vec<Line> = fs::read_to_string("parameters/round_numbers.txt")
             .expect("failed to read round numbers file: `parameters/round_numbers.txt`")
             .lines()
-            .skip_while(|line| line.starts_with("#"))
+            .skip_while(|line| line.starts_with('#'))
             .map(|line| {
                 let nums: Vec<usize> = line
-                    .split(" ")
+                    .split(' ')
                     .map(|s| {
-                        s.parse()
-                            .expect(&format!("failed to parse line as `usize`s: {}", line))
+                        s.parse().unwrap_or_else(|_| {
+                            panic!("failed to parse line as `usize`s: {}", line)
+                        })
                     })
                     .collect();
                 assert_eq!(nums.len(), 5, "line in does not contain 5 values: {}", line);
@@ -140,7 +141,7 @@ mod tests {
             .collect();
 
         assert!(
-            lines.len() > 0,
+            !lines.is_empty(),
             "no lines were parsed from `round_numbers.txt`",
         );
 

--- a/src/triton/gpu.rs
+++ b/src/triton/gpu.rs
@@ -709,7 +709,7 @@ mod tests {
     fn test_mbatch_hash8() {
         let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
         let ctx = cl::default_futhark_context().unwrap();
-        let mut state = if let BatcherState::Arity8(s) =
+        let state = if let BatcherState::Arity8(s) =
             init_hash8(&mut ctx.lock().unwrap(), Strength::Standard).unwrap()
         {
             s
@@ -732,7 +732,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         let (hashes, _) =
-            mbatch_hash8(&mut ctx.lock().unwrap(), &mut state, preimages.as_slice()).unwrap();
+            mbatch_hash8(&mut ctx.lock().unwrap(), &state, preimages.as_slice()).unwrap();
         let gpu_hashes = gpu_hasher.hash(&preimages).unwrap();
         let expected_hashes: Vec<_> = simple_hasher.hash(&preimages).unwrap();
 
@@ -744,7 +744,7 @@ mod tests {
     fn test_mbatch_hash8s() {
         let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
         let ctx = cl::default_futhark_context().unwrap();
-        let mut state = if let BatcherState::Arity8s(s) =
+        let state = if let BatcherState::Arity8s(s) =
             init_hash8(&mut ctx.lock().unwrap(), Strength::Strengthened).unwrap()
         {
             s
@@ -767,7 +767,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         let (hashes, _) =
-            mbatch_hash8s(&mut ctx.lock().unwrap(), &mut state, preimages.as_slice()).unwrap();
+            mbatch_hash8s(&mut ctx.lock().unwrap(), &state, preimages.as_slice()).unwrap();
         let gpu_hashes = gpu_hasher.hash(&preimages).unwrap();
         let expected_hashes: Vec<_> = simple_hasher.hash(&preimages).unwrap();
 
@@ -779,7 +779,7 @@ mod tests {
     fn test_mbatch_hash11() {
         let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
         let ctx = cl::default_futhark_context().unwrap();
-        let mut state = if let BatcherState::Arity11(s) =
+        let state = if let BatcherState::Arity11(s) =
             init_hash11(&mut ctx.lock().unwrap(), Strength::Standard).unwrap()
         {
             s
@@ -802,7 +802,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         let (hashes, _) =
-            mbatch_hash11(&mut ctx.lock().unwrap(), &mut state, preimages.as_slice()).unwrap();
+            mbatch_hash11(&mut ctx.lock().unwrap(), &state, preimages.as_slice()).unwrap();
         let gpu_hashes = gpu_hasher.hash(&preimages).unwrap();
         let expected_hashes: Vec<_> = simple_hasher.hash(&preimages).unwrap();
 
@@ -814,7 +814,7 @@ mod tests {
     fn test_mbatch_hash11s() {
         let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
         let ctx = cl::default_futhark_context().unwrap();
-        let mut state = if let BatcherState::Arity11s(s) =
+        let state = if let BatcherState::Arity11s(s) =
             init_hash11(&mut ctx.lock().unwrap(), Strength::Strengthened).unwrap()
         {
             s
@@ -837,7 +837,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         let (hashes, _) =
-            mbatch_hash11s(&mut ctx.lock().unwrap(), &mut state, preimages.as_slice()).unwrap();
+            mbatch_hash11s(&mut ctx.lock().unwrap(), &state, preimages.as_slice()).unwrap();
         let gpu_hashes = gpu_hasher.hash(&preimages).unwrap();
         let expected_hashes: Vec<_> = simple_hasher.hash(&preimages).unwrap();
 
@@ -848,7 +848,7 @@ mod tests {
     fn test_mbatch_hash8_on_device(dev: Arc<Mutex<FutharkContext>>) {
         let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
         let ctx = cl::default_futhark_context().unwrap();
-        let mut state = if let BatcherState::Arity8(s) =
+        let state = if let BatcherState::Arity8(s) =
             init_hash8(&mut ctx.lock().unwrap(), Strength::Standard).unwrap()
         {
             s
@@ -867,7 +867,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         let (hashes, _) =
-            mbatch_hash8(&mut ctx.lock().unwrap(), &mut state, preimages.as_slice()).unwrap();
+            mbatch_hash8(&mut ctx.lock().unwrap(), &state, preimages.as_slice()).unwrap();
         let gpu_hashes = gpu_hasher.hash(&preimages).unwrap();
         let expected_hashes: Vec<_> = simple_hasher.hash(&preimages).unwrap();
 


### PR DESCRIPTION
Clippy is run on CI, but even if there are warnings, the CI doesn't
fail. With this commit the CI fails when there are Clippy warnings.
It also runs Clippy on all the code (also benchmarks and examples)
now.