### PR TITLE
refactor: remove GPUSelector

### DIFF
--- a/gbench/src/main.rs
+++ b/gbench/src/main.rs
@@ -8,7 +8,7 @@ use neptune::batch_hasher::BatcherType;
 use neptune::column_tree_builder::{ColumnTreeBuilder, ColumnTreeBuilderTrait};
 use neptune::error::Error;
 use neptune::BatchHasher;
-use rust_gpu_tools::opencl::GPUSelector;
+use rust_gpu_tools::opencl::Device;
 use std::result::Result;
 use std::thread;
 use std::time::Instant;
@@ -138,7 +138,11 @@ fn main() -> Result<(), Error> {
         .map(|v| {
             v.split(",")
                 .map(|s| s.parse::<u32>().expect("Invalid Bus-Id number!"))
-                .map(|bus_id| BatcherType::CustomGPU(GPUSelector::BusId(bus_id)))
+                .map(|bus_id| {
+                    let device = Device::by_bus_id(bus_id)
+                        .expect(&format!("No device with Bus-ID {} found!", bus_id));
+                    BatcherType::FromDevice(device.clone())
+                })
                 .collect::<Vec<_>>()
         })
         .unwrap_or(vec![default_type]);

--- a/src/batch_hasher.rs
+++ b/src/batch_hasher.rs
@@ -3,26 +3,23 @@ use std::fmt::{self, Debug};
 use std::marker::PhantomData;
 use std::sync::{Arc, Mutex};
 
-use crate::error::Error;
+use crate::error::{ClError, Error};
 use crate::poseidon::SimplePoseidonBatchHasher;
 #[cfg(feature = "opencl")]
-use crate::proteus::gpu::{get_device, CLBatchHasher};
+use crate::proteus::gpu::CLBatchHasher;
 #[cfg(feature = "gpu")]
 use crate::triton::cl;
 use crate::{Arity, BatchHasher, Strength, DEFAULT_STRENGTH};
 use bellperson::bls::Fr;
 use generic_array::GenericArray;
-use rust_gpu_tools::opencl::GPUSelector;
 
 #[cfg(feature = "gpu")]
 use triton::FutharkContext;
 
 #[derive(Clone)]
 pub enum BatcherType {
-    #[cfg(any(feature = "gpu", feature = "opencl"))]
-    CustomGPU(GPUSelector),
     #[cfg(feature = "gpu")]
-    FromFutharkContext(Arc<Mutex<FutharkContext>>),
+    FromDevice(opencl::Device),
     #[cfg(feature = "opencl")]
     FromDevice(opencl::Device),
     #[cfg(feature = "gpu")]
@@ -37,11 +34,9 @@ impl Debug for BatcherType {
         f.write_fmt(format_args!("BatcherType::"))?;
         match self {
             #[cfg(feature = "gpu")]
-            BatcherType::FromFutharkContext(_) => f.write_fmt(format_args!("FromFutharkContext")),
+            BatcherType::FromDevice(_) => f.write_fmt(format_args!("FromDevice")),
             #[cfg(feature = "opencl")]
             BatcherType::FromDevice(_) => f.write_fmt(format_args!("FromDevice")),
-            #[cfg(any(feature = "gpu", feature = "opencl"))]
-            BatcherType::CustomGPU(x) => f.write_fmt(format_args!("CustomGPU({:?})", x)),
             BatcherType::CPU => f.write_fmt(format_args!("CPU")),
             #[cfg(feature = "gpu")]
             BatcherType::GPU => f.write_fmt(format_args!("GPU")),
@@ -99,31 +94,23 @@ where
                 max_batch_size,
             )?)),
             #[cfg(feature = "gpu")]
-            BatcherType::CustomGPU(selector) => {
+            BatcherType::FromDevice(device) => {
+                let futhark_context = cl::futhark_context(&device)?;
                 Ok(Batcher::GPU(GPUBatchHasher::<A>::new_with_strength(
-                    cl::futhark_context(*selector)?,
-                    strength,
-                    max_batch_size,
-                )?))
-            }
-            #[cfg(feature = "gpu")]
-            BatcherType::FromFutharkContext(futhark_context) => {
-                Ok(Batcher::GPU(GPUBatchHasher::<A>::new_with_strength(
-                    futhark_context.clone(),
+                    futhark_context,
                     strength,
                     max_batch_size,
                 )?))
             }
             #[cfg(feature = "opencl")]
-            BatcherType::OpenCL => Ok(Batcher::OpenCL(CLBatchHasher::<A>::new_with_strength(
-                get_device(&GPUSelector::Index(0))?,
-                strength,
-                max_batch_size,
-            )?)),
-            #[cfg(feature = "opencl")]
-            BatcherType::CustomGPU(selector) => {
+            BatcherType::OpenCL => {
+                let all = opencl::Device::all();
+                let device = all
+                    .first()
+                    .ok_or_else(|| Error::ClError(ClError::DeviceNotFound))?;
+
                 Ok(Batcher::OpenCL(CLBatchHasher::<A>::new_with_strength(
-                    get_device(selector)?,
+                    device,
                     strength,
                     max_batch_size,
                 )?))
@@ -132,22 +119,6 @@ where
             BatcherType::FromDevice(device) => Ok(Batcher::OpenCL(
                 CLBatchHasher::<A>::new_with_strength(&device, strength, max_batch_size)?,
             )),
-        }
-    }
-
-    #[cfg(feature = "gpu")]
-    pub(crate) fn futhark_context(&self) -> Option<Arc<Mutex<FutharkContext>>> {
-        match self {
-            Batcher::GPU(b) => Some(b.futhark_context()),
-            _ => None,
-        }
-    }
-
-    #[cfg(feature = "opencl")]
-    pub(crate) fn device(&self) -> Option<opencl::Device> {
-        match self {
-            Batcher::OpenCL(b) => Some(b.device()),
-            _ => None,
         }
     }
 }

--- a/src/column_tree_builder.rs
+++ b/src/column_tree_builder.rs
@@ -6,8 +6,6 @@ use crate::{Arity, BatchHasher};
 use bellperson::bls::{Bls12, Fr};
 use ff::Field;
 use generic_array::GenericArray;
-#[cfg(all(feature = "gpu", not(target_os = "macos")))]
-use rust_gpu_tools::opencl::GPUSelector;
 
 pub trait ColumnTreeBuilderTrait<ColumnArity, TreeArity>
 where
@@ -118,31 +116,7 @@ where
             None => None,
         };
 
-        let tree_builder = match {
-            match &column_batcher {
-                #[cfg(feature = "gpu")]
-                Some(b) => b.futhark_context(),
-                #[cfg(feature = "opencl")]
-                Some(b) => b.device(),
-                None => None,
-            }
-        } {
-            #[cfg(feature = "gpu")]
-            Some(ctx) => TreeBuilder::<TreeArity>::new(
-                Some(BatcherType::FromFutharkContext(ctx)),
-                leaf_count,
-                max_tree_batch_size,
-                0,
-            )?,
-            #[cfg(feature = "opencl")]
-            Some(device) => TreeBuilder::<TreeArity>::new(
-                Some(BatcherType::FromDevice(device)),
-                leaf_count,
-                max_tree_batch_size,
-                0,
-            )?,
-            None => TreeBuilder::<TreeArity>::new(t, leaf_count, max_tree_batch_size, 0)?,
-        };
+        let tree_builder = TreeBuilder::<TreeArity>::new(t, leaf_count, max_tree_batch_size, 0)?;
 
         let builder = Self {
             leaf_count,

--- a/src/tree_builder.rs
+++ b/src/tree_builder.rs
@@ -5,8 +5,6 @@ use crate::{Arity, BatchHasher};
 use bellperson::bls::{Bls12, Fr};
 use ff::Field;
 use generic_array::GenericArray;
-#[cfg(all(feature = "gpu", not(target_os = "macos")))]
-use rust_gpu_tools::opencl::GPUSelector;
 
 pub trait TreeBuilderTrait<TreeArity>
 where


### PR DESCRIPTION
The rust-gpu-tools GPUSelector added unnecessary complexity.