### PR TITLE
Remove batcher type

### DIFF
--- a/gbench/src/main.rs
+++ b/gbench/src/main.rs
@@ -4,10 +4,9 @@ use generic_array::sequence::GenericSequence;
 use generic_array::typenum::{U11, U8};
 use generic_array::GenericArray;
 use log::info;
-use neptune::batch_hasher::BatcherType;
 use neptune::column_tree_builder::{ColumnTreeBuilder, ColumnTreeBuilderTrait};
 use neptune::error::Error;
-use neptune::BatchHasher;
+use neptune::{batch_hasher::Batcher, BatchHasher};
 use rust_gpu_tools::opencl::Device;
 use std::result::Result;
 use std::thread;
@@ -16,19 +15,14 @@ use structopt::StructOpt;
 
 fn bench_column_building(
     log_prefix: &str,
-    batcher_type: Option<BatcherType>,
+    column_batcher: Batcher<U11>,
+    tree_batcher: Batcher<U8>,
     leaves: usize,
-    max_column_batch_size: usize,
-    max_tree_batch_size: usize,
 ) -> Fr {
     info!("{}: Creating ColumnTreeBuilder", log_prefix);
-    let mut builder = ColumnTreeBuilder::<U11, U8>::new(
-        batcher_type,
-        leaves,
-        max_column_batch_size,
-        max_tree_batch_size,
-    )
-    .unwrap();
+    let mut builder =
+        ColumnTreeBuilder::<U11, U8>::new(Some(column_batcher), Some(tree_batcher), leaves)
+            .unwrap();
     info!("{}: ColumnTreeBuilder created", log_prefix);
 
     // Simplify computing the expected root.
@@ -128,38 +122,31 @@ fn main() -> Result<(), Error> {
     // Comma separated list of GPU bus-ids
     let gpus = std::env::var("NEPTUNE_GBENCH_GPUS");
 
-    #[cfg(feature = "gpu")]
-    let default_type = BatcherType::GPU;
+    #[cfg(any(feature = "gpu", feature = "opencl"))]
+    let default_device = Device::all().first().unwrap().clone();
 
-    #[cfg(feature = "opencl")]
-    let default_type = BatcherType::OpenCL;
-
-    let batcher_types = gpus
+    let devices = gpus
         .map(|v| {
             v.split(",")
                 .map(|s| s.parse::<u32>().expect("Invalid Bus-Id number!"))
                 .map(|bus_id| {
                     let device = Device::by_bus_id(bus_id)
                         .expect(&format!("No device with Bus-ID {} found!", bus_id));
-                    BatcherType::FromDevice(device.clone())
+                    device
                 })
                 .collect::<Vec<_>>()
         })
-        .unwrap_or(vec![default_type]);
+        .unwrap_or(vec![default_device]);
 
     let mut threads = Vec::new();
-    for batcher_type in batcher_types {
+    for device in devices {
         threads.push(thread::spawn(move || {
-            let log_prefix = format!("GPU[Selector: {:?}]", batcher_type);
+            let log_prefix = format!("GPU[{:?}]", device);
             for i in 0..3 {
                 info!("{} --> Run {}", log_prefix, i);
-                bench_column_building(
-                    &log_prefix,
-                    Some(batcher_type.clone()),
-                    leaves,
-                    max_column_batch_size,
-                    max_tree_batch_size,
-                );
+                let column_batcher = Batcher::new(device, max_column_batch_size).unwrap();
+                let tree_batcher = Batcher::new(device, max_tree_batch_size).unwrap();
+                bench_column_building(&log_prefix, column_batcher, tree_batcher, leaves);
             }
         }));
     }

--- a/src/batch_hasher.rs
+++ b/src/batch_hasher.rs
@@ -16,36 +16,6 @@ use generic_array::GenericArray;
 #[cfg(feature = "gpu")]
 use triton::FutharkContext;
 
-#[derive(Clone)]
-pub enum BatcherType {
-    #[cfg(feature = "gpu")]
-    FromDevice(opencl::Device),
-    #[cfg(feature = "opencl")]
-    FromDevice(opencl::Device),
-    #[cfg(feature = "gpu")]
-    GPU,
-    CPU,
-    #[cfg(feature = "opencl")]
-    OpenCL,
-}
-
-impl Debug for BatcherType {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_fmt(format_args!("BatcherType::"))?;
-        match self {
-            #[cfg(feature = "gpu")]
-            BatcherType::FromDevice(_) => f.write_fmt(format_args!("FromDevice")),
-            #[cfg(feature = "opencl")]
-            BatcherType::FromDevice(_) => f.write_fmt(format_args!("FromDevice")),
-            BatcherType::CPU => f.write_fmt(format_args!("CPU")),
-            #[cfg(feature = "gpu")]
-            BatcherType::GPU => f.write_fmt(format_args!("GPU")),
-            #[cfg(feature = "opencl")]
-            BatcherType::OpenCL => f.write_fmt(format_args!("OpenCL")),
-        }
-    }
-}
-
 #[cfg(feature = "gpu")]
 use crate::triton::gpu::GPUBatchHasher;
 
@@ -53,73 +23,90 @@ pub enum Batcher<A>
 where
     A: Arity<Fr>,
 {
+    Cpu(SimplePoseidonBatchHasher<A>),
     #[cfg(feature = "gpu")]
-    GPU(GPUBatchHasher<A>),
-    CPU(SimplePoseidonBatchHasher<A>),
+    OpenCl(GPUBatchHasher<A>),
     #[cfg(feature = "opencl")]
-    OpenCL(CLBatchHasher<A>),
+    OpenCl(CLBatchHasher<A>),
 }
 
 impl<A> Batcher<A>
 where
     A: Arity<Fr>,
 {
-    pub(crate) fn t(&self) -> BatcherType {
-        match self {
-            #[cfg(feature = "gpu")]
-            Batcher::GPU(_) => BatcherType::GPU,
-            Batcher::CPU(_) => BatcherType::CPU,
-            #[cfg(feature = "opencl")]
-            Batcher::OpenCL(_) => BatcherType::OpenCL,
-        }
+    /// Create a new CPU batcher.
+    pub fn new_cpu(max_batch_size: usize) -> Self {
+        Self::with_strength_cpu(DEFAULT_STRENGTH, max_batch_size)
     }
 
-    pub(crate) fn new(t: &BatcherType, max_batch_size: usize) -> Result<Self, Error> {
-        Self::new_with_strength(DEFAULT_STRENGTH, t, max_batch_size)
+    /// Create a new CPU batcher with a specified strength.
+    pub fn with_strength_cpu(strength: Strength, max_batch_size: usize) -> Self {
+        Self::Cpu(SimplePoseidonBatchHasher::<A>::new_with_strength(
+            strength,
+            max_batch_size,
+        ))
     }
 
-    pub(crate) fn new_with_strength(
+    /// Create a new GPU batcher for an arbitrarily picked device.
+    #[cfg(feature = "gpu")]
+    pub fn pick_gpu(max_batch_size: usize) -> Result<Self, Error> {
+        let futhark_context = cl::default_futhark_context()?;
+        Ok(Self::OpenCl(GPUBatchHasher::<A>::new_with_strength(
+            futhark_context,
+            DEFAULT_STRENGTH,
+            max_batch_size,
+        )?))
+    }
+
+    /// Create a new GPU batcher for an arbitrarily picked device.
+    #[cfg(feature = "opencl")]
+    pub fn pick_gpu(max_batch_size: usize) -> Result<Self, Error> {
+        let all = opencl::Device::all();
+        let device = all
+            .first()
+            .ok_or_else(|| Error::ClError(ClError::DeviceNotFound))?;
+        Self::new(device, max_batch_size)
+    }
+
+    #[cfg(feature = "gpu")]
+    /// Create a new GPU batcher for a certain device.
+    pub fn new(device: &opencl::Device, max_batch_size: usize) -> Result<Self, Error> {
+        Self::with_strength(device, DEFAULT_STRENGTH, max_batch_size)
+    }
+
+    #[cfg(feature = "opencl")]
+    /// Create a new GPU batcher for a certain device.
+    pub fn new(device: &opencl::Device, max_batch_size: usize) -> Result<Self, Error> {
+        Self::with_strength(device, DEFAULT_STRENGTH, max_batch_size)
+    }
+
+    #[cfg(feature = "gpu")]
+    /// Create a new GPU batcher for a certain device with a specified strength.
+    pub fn with_strength(
+        device: &opencl::Device,
         strength: Strength,
-        t: &BatcherType,
         max_batch_size: usize,
     ) -> Result<Self, Error> {
-        match t {
-            BatcherType::CPU => Ok(Batcher::CPU(
-                SimplePoseidonBatchHasher::<A>::new_with_strength(strength, max_batch_size)?,
-            )),
-            #[cfg(feature = "gpu")]
-            BatcherType::GPU => Ok(Batcher::GPU(GPUBatchHasher::<A>::new_with_strength(
-                cl::default_futhark_context()?,
-                strength,
-                max_batch_size,
-            )?)),
-            #[cfg(feature = "gpu")]
-            BatcherType::FromDevice(device) => {
-                let futhark_context = cl::futhark_context(&device)?;
-                Ok(Batcher::GPU(GPUBatchHasher::<A>::new_with_strength(
-                    futhark_context,
-                    strength,
-                    max_batch_size,
-                )?))
-            }
-            #[cfg(feature = "opencl")]
-            BatcherType::OpenCL => {
-                let all = opencl::Device::all();
-                let device = all
-                    .first()
-                    .ok_or_else(|| Error::ClError(ClError::DeviceNotFound))?;
+        let futhark_context = cl::futhark_context(&device)?;
+        Ok(Self::OpenCl(GPUBatchHasher::<A>::new_with_strength(
+            futhark_context,
+            strength,
+            max_batch_size,
+        )?))
+    }
 
-                Ok(Batcher::OpenCL(CLBatchHasher::<A>::new_with_strength(
-                    device,
-                    strength,
-                    max_batch_size,
-                )?))
-            }
-            #[cfg(feature = "opencl")]
-            BatcherType::FromDevice(device) => Ok(Batcher::OpenCL(
-                CLBatchHasher::<A>::new_with_strength(&device, strength, max_batch_size)?,
-            )),
-        }
+    #[cfg(feature = "opencl")]
+    /// Create a new GPU batcher for a certain device with a specified strength.
+    pub fn with_strength(
+        device: &opencl::Device,
+        strength: Strength,
+        max_batch_size: usize,
+    ) -> Result<Self, Error> {
+        Ok(Self::OpenCl(CLBatchHasher::<A>::new_with_strength(
+            &device,
+            strength,
+            max_batch_size,
+        )?))
     }
 }
 
@@ -129,21 +116,17 @@ where
 {
     fn hash(&mut self, preimages: &[GenericArray<Fr, A>]) -> Result<Vec<Fr>, Error> {
         match self {
-            Batcher::CPU(batcher) => batcher.hash(preimages),
-            #[cfg(feature = "gpu")]
-            Batcher::GPU(batcher) => batcher.hash(preimages),
-            #[cfg(feature = "opencl")]
-            Batcher::OpenCL(batcher) => batcher.hash(preimages),
+            Batcher::Cpu(batcher) => batcher.hash(preimages),
+            #[cfg(any(feature = "gpu", feature = "opencl"))]
+            Batcher::OpenCl(batcher) => batcher.hash(preimages),
         }
     }
 
     fn max_batch_size(&self) -> usize {
         match self {
-            Batcher::CPU(batcher) => batcher.max_batch_size(),
-            #[cfg(feature = "gpu")]
-            Batcher::GPU(batcher) => batcher.max_batch_size(),
-            #[cfg(feature = "opencl")]
-            Batcher::OpenCL(batcher) => batcher.max_batch_size(),
+            Batcher::Cpu(batcher) => batcher.max_batch_size(),
+            #[cfg(any(feature = "gpu", feature = "opencl"))]
+            Batcher::OpenCl(batcher) => batcher.max_batch_size(),
         }
     }
 }

--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -543,18 +543,15 @@ impl<A> SimplePoseidonBatchHasher<A>
 where
     A: Arity<Fr>,
 {
-    pub(crate) fn new(max_batch_size: usize) -> Result<Self, Error> {
+    pub(crate) fn new(max_batch_size: usize) -> Self {
         Self::new_with_strength(DEFAULT_STRENGTH, max_batch_size)
     }
 
-    pub(crate) fn new_with_strength(
-        strength: Strength,
-        max_batch_size: usize,
-    ) -> Result<Self, Error> {
-        Ok(Self {
+    pub(crate) fn new_with_strength(strength: Strength, max_batch_size: usize) -> Self {
+        Self {
             constants: PoseidonConstants::<Bls12, A>::new_with_strength(strength),
             max_batch_size,
-        })
+        }
     }
 }
 impl<A> BatchHasher<A> for SimplePoseidonBatchHasher<A>

--- a/src/proteus/gpu.rs
+++ b/src/proteus/gpu.rs
@@ -285,8 +285,7 @@ mod test {
         let mut cl_hasher =
             CLBatchHasher::<U2>::new_with_strength(device, Strength::Standard, batch_size).unwrap();
         let mut simple_hasher =
-            SimplePoseidonBatchHasher::<U2>::new_with_strength(Strength::Standard, batch_size)
-                .unwrap();
+            SimplePoseidonBatchHasher::<U2>::new_with_strength(Strength::Standard, batch_size);
 
         let preimages = (0..batch_size)
             .map(|_| GenericArray::<Fr, U2>::generate(|_| Fr::random(&mut rng)))

--- a/src/triton/gpu.rs
+++ b/src/triton/gpu.rs
@@ -658,8 +658,7 @@ mod tests {
         )
         .unwrap();
         let mut simple_hasher =
-            SimplePoseidonBatchHasher::<U2>::new_with_strength(Strength::Standard, batch_size)
-                .unwrap();
+            SimplePoseidonBatchHasher::<U2>::new_with_strength(Strength::Standard, batch_size);
 
         let preimages = (0..batch_size)
             .map(|_| GenericArray::<Fr, U2>::generate(|_| Fr::random(&mut rng)))
@@ -695,8 +694,7 @@ mod tests {
         )
         .unwrap();
         let mut simple_hasher =
-            SimplePoseidonBatchHasher::<U2>::new_with_strength(Strength::Strengthened, batch_size)
-                .unwrap();
+            SimplePoseidonBatchHasher::<U2>::new_with_strength(Strength::Strengthened, batch_size);
 
         let preimages = (0..batch_size)
             .map(|_| GenericArray::<Fr, U2>::generate(|_| Fr::random(&mut rng)))
@@ -731,8 +729,7 @@ mod tests {
         )
         .unwrap();
         let mut simple_hasher =
-            SimplePoseidonBatchHasher::<U8>::new_with_strength(Strength::Standard, batch_size)
-                .unwrap();
+            SimplePoseidonBatchHasher::<U8>::new_with_strength(Strength::Standard, batch_size);
 
         let preimages = (0..batch_size)
             .map(|_| GenericArray::<Fr, U8>::generate(|_| Fr::random(&mut rng)))
@@ -767,8 +764,7 @@ mod tests {
         )
         .unwrap();
         let mut simple_hasher =
-            SimplePoseidonBatchHasher::<U8>::new_with_strength(Strength::Strengthened, batch_size)
-                .unwrap();
+            SimplePoseidonBatchHasher::<U8>::new_with_strength(Strength::Strengthened, batch_size);
 
         let preimages = (0..batch_size)
             .map(|_| GenericArray::<Fr, U8>::generate(|_| Fr::random(&mut rng)))
@@ -803,8 +799,7 @@ mod tests {
         )
         .unwrap();
         let mut simple_hasher =
-            SimplePoseidonBatchHasher::<U11>::new_with_strength(Strength::Standard, batch_size)
-                .unwrap();
+            SimplePoseidonBatchHasher::<U11>::new_with_strength(Strength::Standard, batch_size);
 
         let preimages = (0..batch_size)
             .map(|_| GenericArray::<Fr, U11>::generate(|_| Fr::random(&mut rng)))
@@ -839,8 +834,7 @@ mod tests {
         )
         .unwrap();
         let mut simple_hasher =
-            SimplePoseidonBatchHasher::<U11>::new_with_strength(Strength::Strengthened, batch_size)
-                .unwrap();
+            SimplePoseidonBatchHasher::<U11>::new_with_strength(Strength::Strengthened, batch_size);
 
         let preimages = (0..batch_size)
             .map(|_| GenericArray::<Fr, U11>::generate(|_| Fr::random(&mut rng)))
@@ -870,8 +864,7 @@ mod tests {
         let mut gpu_hasher =
             GPUBatchHasher::<U8>::new_with_strength(dev, Strength::Standard, batch_size).unwrap();
         let mut simple_hasher =
-            SimplePoseidonBatchHasher::<U8>::new_with_strength(Strength::Standard, batch_size)
-                .unwrap();
+            SimplePoseidonBatchHasher::<U8>::new_with_strength(Strength::Standard, batch_size);
 
         let preimages = (0..batch_size)
             .map(|_| GenericArray::<Fr, U8>::generate(|_| Fr::random(&mut rng)))


### PR DESCRIPTION
I went ahead with even more refactoring. The `BatcherType` looked like over-engineering to me. I like the code better without it.

The changes in rust-fil-proofs are quite minimal https://github.com/filecoin-project/rust-fil-proofs/compare/remove-batcher-type and will also be just as minimal for the scheduler work.

I thought if we are already doing breaking changes, we can also cleanup the API a bit.