### PR TITLE
fix: rename gpu feature to futhark

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,12 +35,12 @@ commands:
           no_output_timeout: 5m
 
       - run:
-          name: Test (pairing, GPU) (<< parameters.target >>)
-          command: TARGET=<< parameters.target >> cargo test --release --no-default-features --features pairing,gpu -- --test-threads=1
+          name: Test (pairing, futhark) (<< parameters.target >>)
+          command: TARGET=<< parameters.target >> cargo test --release --no-default-features --features pairing,futhark -- --test-threads=1
           no_output_timeout: 30m
       - run:
-          name: Test (blst, GPU) (<< parameters.target >>)
-          command: TARGET=<< parameters.target >> cargo test --release --no-default-features --features blst,gpu -- --test-threads=1
+          name: Test (blst, futhark) (<< parameters.target >>)
+          command: TARGET=<< parameters.target >> cargo test --release --no-default-features --features blst,futhark -- --test-threads=1
           no_output_timeout: 30m
 
       - run:
@@ -148,11 +148,11 @@ jobs:
           name: Run cargo clippy (blst), without gbench
           command: cargo clippy --all-targets --no-default-features --features blst -- -D warnings
       - run:
-          name: Run cargo clippy (pairing, gpu)
-          command: cargo clippy --workspace --all-targets --no-default-features --features pairing,gpu -- -D warnings
+          name: Run cargo clippy (pairing, futhark)
+          command: cargo clippy --workspace --all-targets --no-default-features --features pairing,futhark -- -D warnings
       - run:
-          name: Run cargo clippy (blst, gpu)
-          command: cargo clippy --workspace --all-targets --no-default-features --features blst,gpu -- -D warnings
+          name: Run cargo clippy (blst, futhark)
+          command: cargo clippy --workspace --all-targets --no-default-features --features blst,futhark -- -D warnings
       - run:
           name: Run cargo clippy (pairing, opencl)
           command: cargo clippy --workspace --all-targets --no-default-features --features pairing,opencl -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ codegen-units = 1
 
 [features]
 default = ["pairing"]
-gpu = ["triton", "rust-gpu-tools"]
+futhark = ["triton", "rust-gpu-tools"]
 opencl = ["rust-gpu-tools"]
 pairing = ["bellperson/pairing"]
 blst = ["bellperson/blst"]

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ proofs (in SNARKs).
 Neptune also supports batch hashing and tree building, which can be performed on a GPU. The underlying GPU
 implementation, [neptune-triton](https://github.com/filecoin-project/neptune-triton) is implemented in the [Futhark
 Programming Language](https://futhark-lang.org/). To use `neptune-triton` GPU batch hashing, compile `neptune` with the
-`gpu` feature.
+`futhark` feature.
 
 Neptune now implements GPU batch hashing in pure OpenCL. The initial implementation is a bit less than 2x faster than
 the Futhark implementation, so once stabilized this will likely be the preferred option. The pure OpenCL batch hashing
 is provided by the internal `proteus` module. To use `proteus`, compile `neptune` with the `opencl` feature.
 
-The `gpu` and `opencl` features are mutually exclusive.
+The `futhark` and `opencl` features are mutually exclusive.
 
 At the time of the 1.0.0 release, Neptune on RTX 2080Ti GPU can build 8-ary Merkle trees for 4GiB of input in 16 seconds.
 

--- a/gbench/Cargo.toml
+++ b/gbench/Cargo.toml
@@ -20,8 +20,8 @@ rust-gpu-tools = { version = "0.3.0", optional = true }
 structopt = { version = "0.3", default-features = false }
 
 [features]
-default = ["pairing", "gpu"]
-gpu = ["neptune/gpu", "rust-gpu-tools"]
+default = ["pairing", "futhark"]
+futhark = ["neptune/futhark", "rust-gpu-tools"]
 opencl = ["neptune/opencl", "rust-gpu-tools"]
 pairing = ["neptune/pairing", "bellperson/pairing"]
 blst = ["neptune/blst", "bellperson/blst"]

--- a/gbench/src/main.rs
+++ b/gbench/src/main.rs
@@ -120,7 +120,6 @@ fn main() {
     // Comma separated list of GPU bus-ids
     let gpus = std::env::var("NEPTUNE_GBENCH_GPUS");
 
-    #[cfg(any(feature = "gpu", feature = "opencl"))]
     let default_device = *Device::all().first().unwrap();
 
     let devices = gpus

--- a/src/column_tree_builder.rs
+++ b/src/column_tree_builder.rs
@@ -141,7 +141,7 @@ where
     }
 }
 
-#[cfg(all(any(feature = "gpu", feature = "opencl"), not(target_os = "macos")))]
+#[cfg(all(any(feature = "futhark", feature = "opencl"), not(target_os = "macos")))]
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -163,7 +163,6 @@ mod tests {
             32,
         );
 
-        #[cfg(any(feature = "gpu", feature = "opencl"))]
         test_column_tree_builder_aux(
             Some(Batcher::pick_gpu(512).unwrap()),
             Some(Batcher::pick_gpu(512).unwrap()),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,9 @@
-#[cfg(feature = "gpu")]
+#[cfg(feature = "futhark")]
 use crate::triton::cl;
 use std::{error, fmt};
 
 #[derive(Debug, Clone)]
-#[cfg(any(feature = "gpu", feature = "opencl"))]
+#[cfg(any(feature = "futhark", feature = "opencl"))]
 pub enum ClError {
     DeviceNotFound,
     PlatformNotFound,
@@ -16,10 +16,10 @@ pub enum ClError {
     GetDeviceError,
 }
 
-#[cfg(any(feature = "gpu", feature = "opencl"))]
+#[cfg(any(feature = "futhark", feature = "opencl"))]
 pub type ClResult<T> = std::result::Result<T, ClError>;
 
-#[cfg(any(feature = "gpu", feature = "opencl"))]
+#[cfg(any(feature = "futhark", feature = "opencl"))]
 impl fmt::Display for ClError {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match self {
@@ -51,22 +51,22 @@ pub enum Error {
     IndexOutOfBounds,
     /// The provided leaf was not found in the tree
     GpuError(String),
-    #[cfg(any(feature = "gpu", feature = "opencl"))]
+    #[cfg(any(feature = "futhark", feature = "opencl"))]
     ClError(ClError),
-    #[cfg(feature = "gpu")]
+    #[cfg(feature = "futhark")]
     TritonError(String),
     DecodingError,
     Other(String),
 }
 
-#[cfg(feature = "gpu")]
+#[cfg(feature = "futhark")]
 impl From<ClError> for Error {
     fn from(e: ClError) -> Self {
         Self::ClError(e)
     }
 }
 
-#[cfg(feature = "gpu")]
+#[cfg(feature = "futhark")]
 impl From<triton::Error> for Error {
     fn from(e: triton::Error) -> Self {
         Self::TritonError(e.to_string())
@@ -84,9 +84,9 @@ impl fmt::Display for Error {
             ),
             Error::IndexOutOfBounds => write!(f, "The referenced index is outs of bounds."),
             Error::GpuError(s) => write!(f, "GPU Error: {}", s),
-            #[cfg(any(feature = "gpu", feature = "opencl"))]
+            #[cfg(any(feature = "futhark", feature = "opencl"))]
             Error::ClError(e) => write!(f, "OpenCL Error: {}", e),
-            #[cfg(feature = "gpu")]
+            #[cfg(feature = "futhark")]
             Error::TritonError(e) => write!(f, "Neptune-triton Error: {}", e),
             Error::DecodingError => write!(f, "PrimeFieldDecodingError"),
             Error::Other(s) => write!(f, "{}", s),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,8 @@ pub use error::Error;
 use ff::{Field, PrimeField, ScalarEngine};
 use generic_array::GenericArray;
 
-#[cfg(all(feature = "gpu", feature = "opencl"))]
-compile_error!("gpu and opencl features are mutually exclusive");
+#[cfg(all(feature = "futhark", feature = "opencl"))]
+compile_error!("futhark and opencl features are mutually exclusive");
 
 /// Poseidon circuit
 pub mod circuit;
@@ -32,18 +32,18 @@ mod round_numbers;
 pub mod hash_type;
 
 /// Tree Builder
-#[cfg(any(feature = "gpu", feature = "opencl"))]
+#[cfg(any(feature = "futhark", feature = "opencl"))]
 pub mod tree_builder;
 
 /// Column Tree Builder
-#[cfg(any(feature = "gpu", feature = "opencl"))]
+#[cfg(any(feature = "futhark", feature = "opencl"))]
 pub mod column_tree_builder;
 
-#[cfg(feature = "gpu")]
+#[cfg(feature = "futhark")]
 pub mod triton;
 
 /// Batch Hasher
-#[cfg(any(feature = "gpu", feature = "opencl"))]
+#[cfg(any(feature = "futhark", feature = "opencl"))]
 pub mod batch_hasher;
 
 #[cfg(feature = "opencl")]

--- a/src/tree_builder.rs
+++ b/src/tree_builder.rs
@@ -240,7 +240,7 @@ where
     }
 }
 
-#[cfg(all(any(feature = "gpu", feature = "opencl"), not(target_os = "macos")))]
+#[cfg(all(any(feature = "futhark", feature = "opencl"), not(target_os = "macos")))]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/triton/gpu.rs
+++ b/src/triton/gpu.rs
@@ -623,7 +623,7 @@ fn u64_vec<U: ArrayLength<Fr>>(vec: &[GenericArray<Fr, U>]) -> Vec<u64> {
 /// So skip GPU tests by default since real code paths are now enabled.
 /// Users will probably not want to actually run with GPU on macos,
 /// But if experiments show it is viable, then it is possible.
-#[cfg(all(feature = "gpu", not(target_os = "macos")))]
+#[cfg(all(feature = "futhark", not(target_os = "macos")))]
 mod tests {
     use super::*;
     use crate::poseidon::{Poseidon, SimplePoseidonBatchHasher};


### PR DESCRIPTION
Having a feature called "gpu" and one called "opencl" is confusing,
as both work with OpenCL. The difference is that the "gpu" feature
code path uses an OpenCL implementation that is written in Futhark.

To make this clearer, the "gpu" feature is renamed to "futhark".

This is my last change in my "cleanup the neptune codebase a bit" series. I'm not sure it is worth doing this change, but having a feature called "gpu" and one called "opencl" certainly confused me when I started to dig into the code. And as we are breaking APIs, we might as well change feature names now.