### PR TITLE
fix: ec_gpu_gen::common() needs to be called

### DIFF
--- a/src/proteus/sources.rs
+++ b/src/proteus/sources.rs
@@ -55,6 +55,7 @@ where
     };
     join(
         &[
+            ec_gpu_gen::common(),
             config(),
             field_source,
             poseidon_source("Fr", derived_constants),


### PR DESCRIPTION
Currently we use the master branch of `ec_gpu_gen`, which contains a
breaking change. You need to call `ec_gpu_gen::common()`, before any
other call.