### PR TITLE
feat: add vanilla Poseidon benchmarks for Pasta scalar fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ sha2 = "0.9"
 tempdir = "0.3"
 rand_xorshift = "0.3.0"
 serde_json = "1.0.53"
+pasta_curves = "0.2.1"
 
 [build-dependencies]
 blstrs = "0.4.0"

--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ As the compile-time of the kernel depends on how many arities are used, there ar
 
     cargo test --no-default-features --features blst,cuda,arity2,arity4,arity8,arity11,arity16,arity24,arity36
 
+## Benchmarking Poseidon by Field and Preimage Length
+
+Benchmark Poseidon over the BLS12-381, Pallas, and Vesta scalar fields for preimages of length `2`, `4`, `8`, or `11` using:
+
+    cargo bench arity-<preimage len>
+
+Benchmark Poseidon over a specific field (`bls`, `pallas`, or `vesta`) and preimage length using:
+
+    cargo bench arity-<preimage len>/<field name>
+
 ## Future Work
 
 The following are likely areas of future work:


### PR DESCRIPTION
Adds benchmarks for vanilla Poseidon using the Pasta scalar fields and commonly used arities (2, 4, 8, 11).