### PR TITLE
feat: support other fields

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ commands:
           no_output_timeout: 5m
       - run:
           name: Test (opencl) (<< parameters.target >>)
-          command: TARGET=<< parameters.target >> cargo test --release --features opencl,arity2,arity4,arity8,arity11,arity16,arity24,arity36 -- --test-threads=1
+          command: TARGET=<< parameters.target >> cargo test --release --features opencl,bls,pasta,arity2,arity4,arity8,arity11,arity16,arity24,arity36 -- --test-threads=1
           no_output_timeout: 30m
       # Darwin CI doesn't support CUDA
       - when:
@@ -57,11 +57,11 @@ commands:
           steps:
             - run:
                 name: Test (cuda) (<< parameters.target >>)
-                command: TARGET=<< parameters.target >> cargo test --release --features cuda,arity2,arity4,arity8,arity11,arity16,arity24,arity36 -- --test-threads=1
+                command: TARGET=<< parameters.target >> cargo test --release --features cuda,bls,pasta,arity2,arity4,arity8,arity11,arity16,arity24,arity36 -- --test-threads=1
                 no_output_timeout: 30m
             - run:
                 name: Test (cuda,opencl) (<< parameters.target >>)
-                command: TARGET=<< parameters.target >> cargo test --release --features cuda,opencl,arity2,arity4,arity8,arity11,arity16,arity24,arity36 -- --test-threads=1
+                command: TARGET=<< parameters.target >> cargo test --release --features cuda,opencl,bls,pasta,arity2,arity4,arity8,arity11,arity16,arity24,arity36 -- --test-threads=1
                 no_output_timeout: 30m
 
 jobs:
@@ -153,13 +153,13 @@ jobs:
           command: cargo clippy --all-targets -- -D warnings
       - run:
           name: Run cargo clippy (opencl)
-          command: cargo clippy --workspace --all-targets --no-default-features --features opencl,arity2 -- -D warnings
+          command: cargo clippy --workspace --all-targets --no-default-features --features opencl,bls,pasta,arity2 -- -D warnings
       - run:
           name: Run cargo clippy (cuda)
-          command: cargo clippy --workspace --all-targets --no-default-features --features cuda,arity2 -- -D warnings
+          command: cargo clippy --workspace --all-targets --no-default-features --features cuda,bls,pasta,arity2 -- -D warnings
       - run:
           name: Run cargo clippy (cuda,opencl)
-          command: cargo clippy --workspace --all-targets --no-default-features --features cuda,opencl,arity2 -- -D warnings
+          command: cargo clippy --workspace --all-targets --no-default-features --features cuda,bls,pasta,opencl,arity2 -- -D warnings
 
 workflows:
   version: 2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,35 +34,19 @@ commands:
             sudo apt update
             sudo apt install -y ocl-icd-opencl-dev
 
-  test_target:
+  test:
     parameters:
-      target:
+      cargo-args:
+        description: Addtional arguments for the cargo command
         type: string
+        default: ""
     steps:
       - *restore-workspace
       - *restore-cache
       - run:
-          name: Test default features (<< parameters.target >>)
-          command: TARGET=<< parameters.target >> cargo test --release
-          no_output_timeout: 5m
-      - run:
-          name: Test (opencl) (<< parameters.target >>)
-          command: TARGET=<< parameters.target >> cargo test --release --features opencl,bls,pasta,arity2,arity4,arity8,arity11,arity16,arity24,arity36 -- --test-threads=1
+          name: Test (<< parameters.cargo-args >>)
+          command: cargo test --release << parameters.cargo-args >> -- --test-threads=1
           no_output_timeout: 30m
-      # Darwin CI doesn't support CUDA
-      - when:
-          condition:
-            not:
-              equal: [ darwin, << parameters.target >> ]
-          steps:
-            - run:
-                name: Test (cuda) (<< parameters.target >>)
-                command: TARGET=<< parameters.target >> cargo test --release --features cuda,bls,pasta,arity2,arity4,arity8,arity11,arity16,arity24,arity36 -- --test-threads=1
-                no_output_timeout: 30m
-            - run:
-                name: Test (cuda,opencl) (<< parameters.target >>)
-                command: TARGET=<< parameters.target >> cargo test --release --features cuda,opencl,bls,pasta,arity2,arity4,arity8,arity11,arity16,arity24,arity36 -- --test-threads=1
-                no_output_timeout: 30m
 
 jobs:
   cargo_fetch:
@@ -99,7 +83,7 @@ jobs:
             - "~/.cargo"
             - "~/.rustup"
 
-  test_x86_64-unknown-linux-gnu:
+  test_default_and_opencl:
     executor: default
     environment:
       RUST_LOG: debug
@@ -109,10 +93,11 @@ jobs:
     steps:
       - set-env-path
       - install-gpu-deps
-      - test_target:
-          target: "x86_64-unknown-linux-gnu"
+      - test
+      - test:
+          cargo-args: "--features opencl,bls,pasta,arity2,arity4,arity8,arity11,arity16,arity24,arity36"
 
-  test_darwin:
+  test_darwin_default_and_opencl:
     macos:
       xcode: "12.5.0"
     working_directory: ~/crate
@@ -127,8 +112,36 @@ jobs:
       - run: rustup default $(cat rust-toolchain)
       - run: cargo update
       - run: cargo fetch
-      - test_target:
-          target: "darwin"
+      - test
+      - test:
+          cargo-args: "--features opencl,bls,pasta,arity2,arity4,arity8,arity11,arity16,arity24,arity36"
+
+  test_cuda:
+    executor: default
+    environment:
+      RUST_LOG: debug
+      # Build the kernel only for the single architecture that is used on CI. This should reduce
+      # the overall compile-time significantly.
+      NEPTUNE_CUDA_NVCC_ARGS: --fatbin --gpu-architecture=sm_75 --generate-code=arch=compute_75,code=sm_75
+    steps:
+      - set-env-path
+      - install-gpu-deps
+      - test:
+          cargo-args: "--features cuda,bls,pasta,arity2,arity4,arity8,arity11,arity16,arity24,arity36"
+
+
+  test_cuda_opencl:
+    executor: default
+    environment:
+      RUST_LOG: debug
+      # Build the kernel only for the single architecture that is used on CI. This should reduce
+      # the overall compile-time significantly.
+      NEPTUNE_CUDA_NVCC_ARGS: --fatbin --gpu-architecture=sm_75 --generate-code=arch=compute_75,code=sm_75
+    steps:
+      - set-env-path
+      - install-gpu-deps
+      - test:
+          cargo-args: "--features cuda,opencl,bls,pasta,arity2,arity4,arity8,arity11,arity16,arity24,arity36"
 
   rustfmt:
     executor: default
@@ -173,9 +186,15 @@ workflows:
       - clippy:
           requires:
             - cargo_fetch
-      - test_x86_64-unknown-linux-gnu:
+      - test_default_and_opencl:
           requires:
             - cargo_fetch
-      - test_darwin:
+      - test_darwin_default_and_opencl:
+          requires:
+            - cargo_fetch
+      - test_cuda:
+          requires:
+            - cargo_fetch
+      - test_cuda_opencl:
           requires:
             - cargo_fetch

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 lazy_static = "1.4.0"
 bellperson = { version = "0.22", default-features = false }
 blake2s_simd = "0.5"
-blstrs = { version = "0.5.0" }
+blstrs = { version = "0.5.0", optional = true }
 byteorder = "1"
 ec-gpu = { version = "0.1.0", optional = true }
 ec-gpu-gen = { version = "0.3.0", default-features = false, optional = true }
@@ -20,16 +20,17 @@ ff = "0.12.0"
 generic-array = "0.14.4"
 itertools = { version = "0.8.0" }
 log = "0.4.8"
+pasta_curves = "0.4.0"
 rust-gpu-tools = { version = "0.5.0", default-features = false, optional = true }
 
 [dev-dependencies]
+blstrs = { version = "0.5.0" }
 criterion = "0.3"
 rand = "0.8.0"
 sha2 = "0.9"
 tempdir = "0.3"
 rand_xorshift = "0.3.0"
 serde_json = "1.0.53"
-pasta_curves = "0.4.0"
 
 [build-dependencies]
 blstrs = "0.5.0"
@@ -37,6 +38,7 @@ ec-gpu = { version = "0.1.0", optional = true }
 ec-gpu-gen = { version = "0.3.0", default-features = false, optional = true }
 execute = "0.2.9"
 hex = "0.4"
+pasta_curves = "0.4.0"
 sha2 = "0.9"
 
 [[bench]]
@@ -66,6 +68,9 @@ arity36 = []
 # With this feature set, also the strengthened version of the kernel will be compiled.
 strengthened = []
 wasm = [ "bellperson/wasm" ]
+# The supported fields for Poseidon running on the GPU are specified at compile-time.
+bls = ["blstrs/gpu"]
+pasta = ["pasta_curves/gpu"]
 
 [workspace]
 members = [

--- a/README.md
+++ b/README.md
@@ -60,11 +60,15 @@ The CUDA/OpenCL kernel (enabled with the `cuda/opencl` feature) is generated wit
 
 When using the `cuda` feature, the kernel is generated at compile-time. The more arities are used, the longer is the compile time. Hence, by default there are no specific arities enabled. You need to set at least one yourself.
 
+### Fields
+
+The CUDA/OpenCL kernel (enabled with the `cuda/opencl` feature) is generated for specific fields. Those fields need to be specified at compile-time via Rust feature flags. Available features are `bls` for BLS12-381 and `pasta` for the Pallas and Vesta curves' scalar fields.
+
 ## Running the tests
 
 As the compile-time of the kernel depends on how many arities are used, there are no arities enabled by default. In order to run the test, all arities need to explicitly be enabled. To run all tests on e.g. the CUDA implementation, run:
 
-    cargo test --no-default-features --features blst,cuda,arity2,arity4,arity8,arity11,arity16,arity24,arity36
+    cargo test --no-default-features --features cuda,bls,pasta,arity2,arity4,arity8,arity11,arity16,arity24,arity36
 
 ## Benchmarking Poseidon by Field and Preimage Length
 

--- a/build.rs
+++ b/build.rs
@@ -6,14 +6,13 @@ fn main() {
     use std::process::Command;
     use std::{env, fs};
 
-    use blstrs::Scalar as Fr;
     use ec_gpu_gen::Limb32;
     use sha2::{Digest, Sha256};
 
     #[path = "src/proteus/sources.rs"]
     mod sources;
 
-    let kernel_source = sources::generate_program::<Fr, Limb32>();
+    let kernel_source = sources::generate_program::<Limb32>();
     let out_dir = env::var("OUT_DIR").expect("OUT_DIR was not set.");
 
     // Make it possible to override the default options. Though the source and output file is
@@ -24,6 +23,8 @@ fn main() {
             let mut command = Command::new("nvcc");
             command
                 .arg("--optimize=6")
+                // Compile with as many threads as CPUs are available.
+                .arg("--threads=0")
                 .arg("--fatbin")
                 .arg("--gpu-architecture=sm_86")
                 .arg("--generate-code=arch=compute_86,code=sm_86")

--- a/gbench/Cargo.toml
+++ b/gbench/Cargo.toml
@@ -15,10 +15,12 @@ env_logger = "0.7.1"
 ff = "0.12.0"
 generic-array = "0.14.4"
 log = "0.4.8"
-neptune = { path = "../", default-features = false, features = ["arity8", "arity11"] }
+neptune = { path = "../", default-features = false, features = ["arity8", "arity11", "bls", "pasta"] }
 rust-gpu-tools = { version = "0.5.0", default-features = false, optional = true }
 structopt = { version = "0.3", default-features = false }
-blstrs = "0.5.0"
+blstrs = { version = "0.5.0", features = ["gpu"] }
+pasta_curves = { version = "0.4.0", features = ["gpu"] }
+ec-gpu = "0.1.0"
 
 [features]
 default = ["opencl"]

--- a/gbench/src/main.rs
+++ b/gbench/src/main.rs
@@ -1,32 +1,38 @@
 use blstrs::Scalar as Fr;
-use ff::Field;
+use ec_gpu::GpuField;
+use ff::PrimeField;
 use generic_array::sequence::GenericSequence;
 use generic_array::typenum::{U11, U8};
 use generic_array::GenericArray;
 use log::info;
 use neptune::column_tree_builder::{ColumnTreeBuilder, ColumnTreeBuilderTrait};
 use neptune::{batch_hasher::Batcher, BatchHasher};
+use pasta_curves::{Fp, Fq as Fv};
 use rust_gpu_tools::{Device, UniqueId};
 use std::convert::TryFrom;
+use std::str::FromStr;
 use std::thread;
 use std::time::Instant;
 use structopt::StructOpt;
 
-fn bench_column_building(
+fn bench_column_building<F: PrimeField + GpuField>(
+    device: &Device,
     log_prefix: &str,
-    column_batcher: Batcher<U11>,
-    tree_batcher: Batcher<U8>,
+    max_column_batch_size: usize,
+    max_tree_batch_size: usize,
     leaves: usize,
-) -> Fr {
+) -> F {
+    let column_batcher = Batcher::<F, U11>::new(device, max_column_batch_size).unwrap();
+    let tree_batcher = Batcher::<F, U8>::new(device, max_tree_batch_size).unwrap();
     info!("{}: Creating ColumnTreeBuilder", log_prefix);
     let mut builder =
-        ColumnTreeBuilder::<U11, U8>::new(Some(column_batcher), Some(tree_batcher), leaves)
+        ColumnTreeBuilder::<F, U11, U8>::new(Some(column_batcher), Some(tree_batcher), leaves)
             .unwrap();
     info!("{}: ColumnTreeBuilder created", log_prefix);
 
     // Simplify computing the expected root.
-    let constant_element = Fr::zero();
-    let constant_column = GenericArray::<Fr, U11>::generate(|_| constant_element);
+    let constant_element = F::zero();
+    let constant_column = GenericArray::<F, U11>::generate(|_| constant_element);
 
     let max_batch_size = if let Some(batcher) = &builder.column_batcher {
         batcher.max_batch_size()
@@ -46,7 +52,7 @@ fn bench_column_building(
     let mut total_columns = 0;
     while total_columns + effective_batch_size < leaves {
         print!(".");
-        let columns: Vec<GenericArray<Fr, U11>> =
+        let columns: Vec<GenericArray<F, U11>> =
             (0..effective_batch_size).map(|_| constant_column).collect();
 
         let _ = builder.add_columns(columns.as_slice()).unwrap();
@@ -55,7 +61,7 @@ fn bench_column_building(
     println!();
 
     let final_columns: Vec<_> = (0..leaves - total_columns)
-        .map(|_| GenericArray::<Fr, U11>::generate(|_| constant_element))
+        .map(|_| GenericArray::<F, U11>::generate(|_| constant_element))
         .collect();
 
     info!(
@@ -90,13 +96,35 @@ fn bench_column_building(
     res[res.len() - 1]
 }
 
-#[derive(Debug, StructOpt, Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
+enum Field {
+    Bls,
+    Pallas,
+    Vesta,
+}
+
+impl FromStr for Field {
+    type Err = &'static str;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        match input {
+            "bls" => Ok(Self::Bls),
+            "pallas" => Ok(Self::Pallas),
+            "vesta" => Ok(Self::Vesta),
+            _ => Err("Unknown field, use `bls`, `pallas` or `vesta`."),
+        }
+    }
+}
+
+#[derive(Debug, StructOpt, Clone)]
 #[structopt(name = "Neptune gbench", about = "Neptune benchmarking program")]
 struct Opts {
     #[structopt(long = "max-tree-batch-size", default_value = "700000")]
     max_tree_batch_size: usize,
     #[structopt(long = "max-column-batch-size", default_value = "400000")]
     max_column_batch_size: usize,
+    #[structopt(long = "field", default_value = "bls", possible_values = &["bls", "pallas", "vesta"])]
+    field: Field,
 }
 
 fn main() {
@@ -106,6 +134,7 @@ fn main() {
 
     let opts = Opts::from_args();
 
+    let field = opts.field;
     let kib = 1024 * 1024 * 4; // 4GiB
                                // let kib = 1024 * 512; // 512MiB
     let bytes = kib * 1024;
@@ -113,6 +142,7 @@ fn main() {
     let max_column_batch_size = opts.max_column_batch_size;
     let max_tree_batch_size = opts.max_tree_batch_size;
 
+    info!("field: {:?}", field);
     info!("KiB: {}", kib);
     info!("leaves: {}", leaves);
     info!("max column batch size: {}", max_column_batch_size);
@@ -141,9 +171,35 @@ fn main() {
             let log_prefix = format!("GPU[{:?}]", device);
             for i in 0..3 {
                 info!("{} --> Run {}", log_prefix, i);
-                let column_batcher = Batcher::new(device, max_column_batch_size).unwrap();
-                let tree_batcher = Batcher::new(device, max_tree_batch_size).unwrap();
-                bench_column_building(&log_prefix, column_batcher, tree_batcher, leaves);
+                match field {
+                    Field::Bls => {
+                        bench_column_building::<Fr>(
+                            device,
+                            &log_prefix,
+                            max_column_batch_size,
+                            max_tree_batch_size,
+                            leaves,
+                        );
+                    }
+                    Field::Pallas => {
+                        bench_column_building::<Fp>(
+                            device,
+                            &log_prefix,
+                            max_column_batch_size,
+                            max_tree_batch_size,
+                            leaves,
+                        );
+                    }
+                    Field::Vesta => {
+                        bench_column_building::<Fv>(
+                            device,
+                            &log_prefix,
+                            max_column_batch_size,
+                            max_tree_batch_size,
+                            leaves,
+                        );
+                    }
+                }
             }
         }));
     }

--- a/src/column_tree_builder.rs
+++ b/src/column_tree_builder.rs
@@ -3,45 +3,47 @@ use crate::error::Error;
 use crate::poseidon::{Poseidon, PoseidonConstants};
 use crate::tree_builder::{TreeBuilder, TreeBuilderTrait};
 use crate::{Arity, BatchHasher};
-use blstrs::Scalar as Fr;
-use ff::Field;
-use generic_array::GenericArray;
+use ff::{Field, PrimeField};
+use generic_array::{ArrayLength, GenericArray};
 
-pub trait ColumnTreeBuilderTrait<ColumnArity, TreeArity>
+pub trait ColumnTreeBuilderTrait<F, ColumnArity, TreeArity>
 where
-    ColumnArity: Arity<Fr>,
-    TreeArity: Arity<Fr>,
+    F: PrimeField,
+    ColumnArity: Arity<F>,
+    TreeArity: Arity<F>,
 {
-    fn add_columns(&mut self, columns: &[GenericArray<Fr, ColumnArity>]) -> Result<(), Error>;
+    fn add_columns(&mut self, columns: &[GenericArray<F, ColumnArity>]) -> Result<(), Error>;
     fn add_final_columns(
         &mut self,
-        columns: &[GenericArray<Fr, ColumnArity>],
-    ) -> Result<(Vec<Fr>, Vec<Fr>), Error>;
+        columns: &[GenericArray<F, ColumnArity>],
+    ) -> Result<(Vec<F>, Vec<F>), Error>;
 
     fn reset(&mut self);
 }
 
-pub struct ColumnTreeBuilder<ColumnArity, TreeArity>
+pub struct ColumnTreeBuilder<F, ColumnArity, TreeArity>
 where
-    ColumnArity: Arity<Fr>,
-    TreeArity: Arity<Fr>,
+    F: PrimeField,
+    ColumnArity: Arity<F>,
+    TreeArity: Arity<F>,
 {
     pub leaf_count: usize,
-    data: Vec<Fr>,
+    data: Vec<F>,
     /// Index of the first unfilled datum.
     fill_index: usize,
-    column_constants: PoseidonConstants<Fr, ColumnArity>,
-    pub column_batcher: Option<Batcher<ColumnArity>>,
-    tree_builder: TreeBuilder<TreeArity>,
+    column_constants: PoseidonConstants<F, ColumnArity>,
+    pub column_batcher: Option<Batcher<F, ColumnArity>>,
+    tree_builder: TreeBuilder<F, TreeArity>,
 }
 
-impl<ColumnArity, TreeArity> ColumnTreeBuilderTrait<ColumnArity, TreeArity>
-    for ColumnTreeBuilder<ColumnArity, TreeArity>
+impl<F, ColumnArity, TreeArity> ColumnTreeBuilderTrait<F, ColumnArity, TreeArity>
+    for ColumnTreeBuilder<F, ColumnArity, TreeArity>
 where
-    ColumnArity: Arity<Fr>,
-    TreeArity: Arity<Fr>,
+    F: PrimeField,
+    ColumnArity: Arity<F>,
+    TreeArity: Arity<F>,
 {
-    fn add_columns(&mut self, columns: &[GenericArray<Fr, ColumnArity>]) -> Result<(), Error> {
+    fn add_columns(&mut self, columns: &[GenericArray<F, ColumnArity>]) -> Result<(), Error> {
         let start = self.fill_index;
         let column_count = columns.len();
         let end = start + column_count;
@@ -67,8 +69,8 @@ where
 
     fn add_final_columns(
         &mut self,
-        columns: &[GenericArray<Fr, ColumnArity>],
-    ) -> Result<(Vec<Fr>, Vec<Fr>), Error> {
+        columns: &[GenericArray<F, ColumnArity>],
+    ) -> Result<(Vec<F>, Vec<F>), Error> {
         self.add_columns(columns)?;
 
         let (base, tree) = self.tree_builder.add_final_leaves(&self.data)?;
@@ -79,44 +81,45 @@ where
 
     fn reset(&mut self) {
         self.fill_index = 0;
-        self.data.iter_mut().for_each(|place| *place = Fr::zero());
+        self.data.iter_mut().for_each(|place| *place = F::zero());
     }
 }
-fn as_generic_arrays<A: Arity<Fr>>(vec: &[Fr]) -> &[GenericArray<Fr, A>] {
+fn as_generic_arrays<A: Arity<F>, F: PrimeField>(vec: &[F]) -> &[GenericArray<F, A>] {
     // It is a programmer error to call `as_generic_arrays` on a vector whose underlying data cannot be divided
     // into an even number of `GenericArray<Fr, Arity>`.
     assert_eq!(
         0,
-        (vec.len() * std::mem::size_of::<Fr>()) % std::mem::size_of::<GenericArray<Fr, A>>()
+        (vec.len() * std::mem::size_of::<F>()) % std::mem::size_of::<GenericArray<F, A>>()
     );
 
     // This block does not affect the underlying `Fr`s. It just groups them into `GenericArray`s of length `Arity`.
     // We know by the assertion above that `vec` can be evenly divided into these units.
     unsafe {
         std::slice::from_raw_parts(
-            vec.as_ptr() as *const () as *const GenericArray<Fr, A>,
+            vec.as_ptr() as *const () as *const GenericArray<F, A>,
             vec.len() / A::to_usize(),
         )
     }
 }
 
-impl<ColumnArity, TreeArity> ColumnTreeBuilder<ColumnArity, TreeArity>
+impl<F, ColumnArity, TreeArity> ColumnTreeBuilder<F, ColumnArity, TreeArity>
 where
-    ColumnArity: Arity<Fr>,
-    TreeArity: Arity<Fr>,
+    F: PrimeField,
+    ColumnArity: Arity<F>,
+    TreeArity: Arity<F>,
 {
     pub fn new(
-        column_batcher: Option<Batcher<ColumnArity>>,
-        tree_batcher: Option<Batcher<TreeArity>>,
+        column_batcher: Option<Batcher<F, ColumnArity>>,
+        tree_batcher: Option<Batcher<F, TreeArity>>,
         leaf_count: usize,
     ) -> Result<Self, Error> {
-        let tree_builder = TreeBuilder::<TreeArity>::new(tree_batcher, leaf_count, 0)?;
+        let tree_builder = TreeBuilder::<F, TreeArity>::new(tree_batcher, leaf_count, 0)?;
 
         let builder = Self {
             leaf_count,
-            data: vec![Fr::zero(); leaf_count],
+            data: vec![F::zero(); leaf_count],
             fill_index: 0,
-            column_constants: PoseidonConstants::<Fr, ColumnArity>::new(),
+            column_constants: PoseidonConstants::<F, ColumnArity>::new(),
             column_batcher,
             tree_builder,
         };
@@ -132,8 +135,8 @@ where
     // without the cost of generating a full column tree.
     pub fn compute_uniform_tree_root(
         &mut self,
-        column: GenericArray<Fr, ColumnArity>,
-    ) -> Result<Fr, Error> {
+        column: GenericArray<F, ColumnArity>,
+    ) -> Result<F, Error> {
         // All the leaves will be the same.
         let element = Poseidon::new_with_preimage(&column, &self.column_constants).hash();
 
@@ -172,15 +175,15 @@ mod tests {
     }
 
     fn test_column_tree_builder_aux(
-        column_batcher: Option<Batcher<U11>>,
-        tree_batcher: Option<Batcher<U8>>,
+        column_batcher: Option<Batcher<Fr, U11>>,
+        tree_batcher: Option<Batcher<Fr, U8>>,
         leaves: usize,
         num_batches: usize,
     ) {
         let batch_size = leaves / num_batches;
 
         let mut builder =
-            ColumnTreeBuilder::<U11, U8>::new(column_batcher, tree_batcher, leaves).unwrap();
+            ColumnTreeBuilder::<Fr, U11, U8>::new(column_batcher, tree_batcher, leaves).unwrap();
 
         // Simplify computing the expected root.
         let constant_element = Fr::zero();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,10 +6,12 @@ extern crate lazy_static;
 pub use crate::poseidon::{Arity, Poseidon};
 use crate::round_constants::generate_constants;
 use crate::round_numbers::{round_numbers_base, round_numbers_strengthened};
+#[cfg(test)]
 use blstrs::Scalar as Fr;
 pub use error::Error;
 use ff::PrimeField;
 use generic_array::GenericArray;
+use std::fmt;
 
 #[cfg(all(
     any(feature = "cuda", feature = "opencl"),
@@ -30,6 +32,12 @@ compile_error!("The `cuda` and `opencl` features need at least one arity feature
     not(any(feature = "cuda", feature = "opencl"))
 ))]
 compile_error!("The `strengthened` feature needs the `cuda` and/or `opencl` feature to be set");
+
+#[cfg(all(
+    any(feature = "cuda", feature = "opencl"),
+    not(any(feature = "bls", feature = "pasta",))
+))]
+compile_error!("The `cuda` and `opencl` features need the `bls` and/or `pasta` feature to be set");
 
 /// Poseidon circuit
 pub mod circuit;
@@ -73,20 +81,30 @@ pub enum Strength {
     Strengthened,
 }
 
+impl fmt::Display for Strength {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Standard => write!(f, "standard"),
+            Self::Strengthened => write!(f, "strengthened"),
+        }
+    }
+}
+
 pub(crate) const DEFAULT_STRENGTH: Strength = Strength::Standard;
 
-pub trait BatchHasher<A>
+pub trait BatchHasher<F, A>
 where
-    A: Arity<Fr>,
+    F: PrimeField,
+    A: Arity<F>,
 {
     // type State;
 
-    fn hash(&mut self, preimages: &[GenericArray<Fr, A>]) -> Result<Vec<Fr>, Error>;
+    fn hash(&mut self, preimages: &[GenericArray<F, A>]) -> Result<Vec<F>, Error>;
 
     fn hash_into_slice(
         &mut self,
-        target_slice: &mut [Fr],
-        preimages: &[GenericArray<Fr, A>],
+        target_slice: &mut [F],
+        preimages: &[GenericArray<F, A>],
     ) -> Result<(), Error> {
         assert_eq!(target_slice.len(), preimages.len());
         // FIXME: Account for max batch size.

--- a/src/proteus/cl/poseidon.cl
+++ b/src/proteus/cl/poseidon.cl
@@ -27,7 +27,7 @@ DEVICE state_{field}_{arity}_{strength} apply_matrix_{field}_{arity}_{strength} 
 DEVICE state_{field}_{arity}_{strength} apply_sparse_matrix_{field}_{arity}_{strength} (CONSTANT {field} sm[{sparse_matrix_size}], state_{field}_{arity}_{strength} s) {{
     {field} first_elt = s.elements[0];
 
-    s.elements[0] = scalar_product(sm + {w_hat_offset}, s.elements, {width});
+    s.elements[0] = scalar_product_{field}(sm + {w_hat_offset}, s.elements, {width});
 
     for (int i = 1; i < {width}; ++i) {{
         {field} val = {field}_mul((sm + {v_rest_offset})[i-1], first_elt);
@@ -67,7 +67,7 @@ DEVICE state_{field}_{arity}_{strength} add_partial_round_key_{field}_{arity}_{s
 
 DEVICE state_{field}_{arity}_{strength} full_round_{field}_{arity}_{strength} (CONSTANT {field} constants[{constants_elements}], state_{field}_{arity}_{strength} s) {{
     for (int i = 0; i < {width}; ++i) {{
-        s.elements[i] = quintic_s_box(s.elements[i], {field}_ZERO, (constants + {round_keys_offset})[s.rk_offset + i]);
+        s.elements[i] = quintic_s_box_{field}(s.elements[i], {field}_ZERO, (constants + {round_keys_offset})[s.rk_offset + i]);
       }}
     s.rk_offset += {width};
     s = apply_round_matrix_{field}_{arity}_{strength}(constants, s);
@@ -77,14 +77,14 @@ DEVICE state_{field}_{arity}_{strength} full_round_{field}_{arity}_{strength} (C
 
 DEVICE state_{field}_{arity}_{strength} last_full_round_{field}_{arity}_{strength} (CONSTANT {field} constants[{constants_elements}], state_{field}_{arity}_{strength} s) {{
     for (int i = 0; i < {width}; ++i) {{
-        s.elements[i] = quintic_s_box(s.elements[i], {field}_ZERO, {field}_ZERO);
+        s.elements[i] = quintic_s_box_{field}(s.elements[i], {field}_ZERO, {field}_ZERO);
       }}
     s = apply_round_matrix_{field}_{arity}_{strength}(constants, s);
     return s;
 }}
 
 DEVICE state_{field}_{arity}_{strength} partial_round_{field}_{arity}_{strength} (CONSTANT {field} constants[{constants_elements}], state_{field}_{arity}_{strength} s) {{
-    s.elements[0] = quintic_s_box(s.elements[0], {field}_ZERO, (constants + {round_keys_offset})[s.rk_offset]);
+    s.elements[0] = quintic_s_box_{field}(s.elements[0], {field}_ZERO, (constants + {round_keys_offset})[s.rk_offset]);
     s.rk_offset += 1;
     s = apply_round_matrix_{field}_{arity}_{strength}(constants, s);
     s.current_round += 1;

--- a/src/proteus/cl/shared.cl
+++ b/src/proteus/cl/shared.cl
@@ -1,4 +1,4 @@
-DEVICE {field} quintic_s_box({field} l, {field} pre_add, {field} post_add) {{
+DEVICE {field} quintic_s_box_{field}({field} l, {field} pre_add, {field} post_add) {{
     {field} tmp = {field}_add(l, pre_add);
     tmp = {field}_sqr(l);
     tmp = {field}_sqr(tmp);
@@ -8,7 +8,7 @@ DEVICE {field} quintic_s_box({field} l, {field} pre_add, {field} post_add) {{
     return tmp;
   }}
 
-DEVICE {field} scalar_product(CONSTANT {field}* a, {field}* b, int size) {{
+DEVICE {field} scalar_product_{field}(CONSTANT {field}* a, {field}* b, int size) {{
     {field} res = {field}_ZERO;
 
     for (int i = 0; i < size; ++i) {{

--- a/src/proteus/gpu.rs
+++ b/src/proteus/gpu.rs
@@ -4,7 +4,7 @@ use crate::error::{ClError, Error};
 use crate::hash_type::HashType;
 use crate::poseidon::PoseidonConstants;
 use crate::{Arity, BatchHasher, Strength, DEFAULT_STRENGTH};
-use blstrs::Scalar as Fr;
+use ec_gpu::GpuField;
 use ff::{Field, PrimeField};
 use generic_array::{typenum, ArrayLength, GenericArray};
 use log::info;
@@ -12,6 +12,11 @@ use rust_gpu_tools::{program_closures, Device, Program};
 use std::collections::HashMap;
 use std::marker::PhantomData;
 use typenum::{U11, U2, U8};
+
+#[cfg(feature = "bls")]
+use blstrs::Scalar as Fr;
+#[cfg(feature = "pasta")]
+use pasta_curves::{Fp, Fq as Fv};
 
 #[cfg(feature = "cuda")]
 use rust_gpu_tools::cuda;
@@ -50,24 +55,27 @@ impl<T> opencl::KernelArgument for Buffer<T> {
 }
 
 #[derive(Debug)]
-struct GpuConstants<A>(PoseidonConstants<Fr, A>)
+struct GpuConstants<F, A>(PoseidonConstants<F, A>)
 where
-    A: Arity<Fr>;
+    F: PrimeField,
+    A: Arity<F>;
 
-pub struct ClBatchHasher<A>
+pub struct ClBatchHasher<F, A>
 where
-    A: Arity<Fr>,
+    F: PrimeField,
+    A: Arity<F>,
 {
     device: Device,
-    constants: GpuConstants<A>,
-    constants_buffer: Buffer<Fr>,
+    constants: GpuConstants<F, A>,
+    constants_buffer: Buffer<F>,
     max_batch_size: usize,
     program: Program,
 }
 
-impl<A> GpuConstants<A>
+impl<F, A> GpuConstants<F, A>
 where
-    A: Arity<Fr>,
+    F: PrimeField,
+    A: Arity<F>,
 {
     fn strength(&self) -> Strength {
         self.0.strength
@@ -77,7 +85,7 @@ where
         DerivedConstants::new(self.0.arity(), self.0.full_rounds, self.0.partial_rounds)
     }
 
-    fn to_vec(&self) -> Vec<Fr> {
+    fn to_vec(&self) -> Vec<F> {
         let constants_elements = self.derived_constants().constants_elements;
 
         let constants = &self.0;
@@ -92,11 +100,19 @@ where
         }
         data
     }
+
+    /// Returns the name of the kernel that can be be called with those contants
+    fn kernel_name(&self, field_name: &str) -> String {
+        let arity = A::to_usize();
+        let strength = self.strength();
+        format!("hash_preimages_{}_{}_{}", field_name, arity, strength)
+    }
 }
 
-impl<A> ClBatchHasher<A>
+impl<F, A> ClBatchHasher<F, A>
 where
-    A: Arity<Fr>,
+    F: PrimeField + GpuField,
+    A: Arity<F>,
 {
     /// Create a new `GPUBatchHasher` and initialize it with state corresponding with its `A`.
     pub(crate) fn new(device: &Device, max_batch_size: usize) -> Result<Self, Error> {
@@ -108,14 +124,14 @@ where
         strength: Strength,
         max_batch_size: usize,
     ) -> Result<Self, Error> {
-        let constants = GpuConstants(PoseidonConstants::<Fr, A>::new_with_strength(strength));
-        let program = program::program::<Fr>(device)?;
+        let constants = GpuConstants(PoseidonConstants::<F, A>::new_with_strength(strength));
+        let program = program::program(device)?;
 
         // Allocate the buffer only once and re-use it in the hashing steps
         let constants_buffer = match program {
             #[cfg(feature = "cuda")]
             Program::Cuda(ref cuda_program) => cuda_program.run(
-                |prog, _| -> Result<Buffer<Fr>, Error> {
+                |prog, _| -> Result<Buffer<F>, Error> {
                     let buffer = prog.create_buffer_from_slice(&constants.to_vec())?;
                     Ok(Buffer::Cuda(buffer))
                 },
@@ -123,7 +139,7 @@ where
             )?,
             #[cfg(feature = "opencl")]
             Program::Opencl(ref opencl_program) => opencl_program.run(
-                |prog, _| -> Result<Buffer<Fr>, Error> {
+                |prog, _| -> Result<Buffer<F>, Error> {
                     let buffer = prog.create_buffer_from_slice(&constants.to_vec())?;
                     Ok(Buffer::OpenCl(buffer))
                 },
@@ -146,11 +162,14 @@ where
 }
 
 const LOCAL_WORK_SIZE: usize = 256;
-impl<A> BatchHasher<A> for ClBatchHasher<A>
+impl<F, A> BatchHasher<F, A> for ClBatchHasher<F, A>
 where
-    A: Arity<Fr>,
+    F: PrimeField,
+    A: Arity<F>,
 {
-    fn hash(&mut self, preimages: &[GenericArray<Fr, A>]) -> Result<Vec<Fr>, Error> {
+    fn hash(&mut self, preimages: &[GenericArray<F, A>]) -> Result<Vec<F>, Error> {
+        use std::any::TypeId;
+
         let local_work_size = LOCAL_WORK_SIZE;
         let max_batch_size = self.max_batch_size;
         let batch_size = preimages.len();
@@ -159,42 +178,29 @@ where
         let global_work_size = calc_global_work_size(batch_size, local_work_size);
         let num_hashes = preimages.len();
 
-        let kernel_name = match (A::to_usize(), self.constants.strength()) {
-            #[cfg(feature = "arity2")]
-            (2, Strength::Standard) => "hash_preimages_Fr_2_standard",
-            #[cfg(all(feature = "arity2", feature = "strengthened"))]
-            (2, Strength::Strengthened) => "hash_preimages_Fr_2_strengthened",
-            #[cfg(feature = "arity4")]
-            (4, Strength::Standard) => "hash_preimages_Fr_4_standard",
-            #[cfg(all(feature = "arity4", feature = "strengthened"))]
-            (4, Strength::Strengthened) => "hash_preimages_Fr_4_strengthened",
-            #[cfg(feature = "arity8")]
-            (8, Strength::Standard) => "hash_preimages_Fr_8_standard",
-            #[cfg(all(feature = "arity8", feature = "strengthened"))]
-            (8, Strength::Strengthened) => "hash_preimages_Fr_8_strengthened",
-            #[cfg(feature = "arity11")]
-            (11, Strength::Standard) => "hash_preimages_Fr_11_standard",
-            #[cfg(all(feature = "arity11", feature = "strengthened"))]
-            (11, Strength::Strengthened) => "hash_preimages_Fr_11_strengthened",
-            #[cfg(feature = "arity16")]
-            (16, Strength::Standard) => "hash_preimages_Fr_16_standard",
-            #[cfg(all(feature = "arity16", feature = "strengthened"))]
-            (16, Strength::Strengthened) => "hash_preimages_Fr_16_strengthened",
-            #[cfg(feature = "arity24")]
-            (24, Strength::Standard) => "hash_preimages_Fr_24_standard",
-            #[cfg(all(feature = "arity24", feature = "strengthened"))]
-            (24, Strength::Strengthened) => "hash_preimages_Fr_24_strengthened",
-            #[cfg(feature = "arity36")]
-            (36, Strength::Standard) => "hash_preimages_Fr_36_standard",
-            #[cfg(all(feature = "arity36", feature = "strengthened"))]
-            (36, Strength::Strengthened) => "hash_preimages_Fr_36_strengthened",
-            (arity, strength) => return Err(Error::GpuError(format!("No kernel for arity {} and strength {:?} available. Try to enable the `arity{}` feature flag.", arity, strength, arity))),
-        };
+        // Only one case can possibly ever match.
+        let mut maybe_kernel_name = None;
+        // Those field names below, that are passed into `kernel_name()`, need to match the ones
+        // in `proteus::source::generate_program`.
+        #[cfg(feature = "bls")]
+        if TypeId::of::<F>() == TypeId::of::<Fr>() {
+            maybe_kernel_name = Some(self.constants.kernel_name("Fr"));
+        }
+        #[cfg(feature = "pasta")]
+        if TypeId::of::<F>() == TypeId::of::<Fp>() {
+            maybe_kernel_name = Some(self.constants.kernel_name("Fp"));
+        }
+        #[cfg(feature = "pasta")]
+        if TypeId::of::<F>() == TypeId::of::<Fv>() {
+            maybe_kernel_name = Some(self.constants.kernel_name("Fv"));
+        }
+        let kernel_name = maybe_kernel_name
+            .ok_or_else(|| Error::GpuError("No kernel found for the given field.".to_string()))?;
 
-        let closures = program_closures!(|program, _args| -> Result<Vec<Fr>, Error> {
-            let kernel = program.create_kernel(kernel_name, global_work_size, local_work_size)?;
+        let closures = program_closures!(|program, _args| -> Result<Vec<F>, Error> {
+            let kernel = program.create_kernel(&kernel_name, global_work_size, local_work_size)?;
             let preimages_buffer = program.create_buffer_from_slice(preimages)?;
-            let result_buffer = unsafe { program.create_buffer::<Fr>(num_hashes)? };
+            let result_buffer = unsafe { program.create_buffer::<F>(num_hashes)? };
 
             kernel
                 .arg(&self.constants_buffer)
@@ -203,7 +209,7 @@ where
                 .arg(&(preimages.len() as i32))
                 .run()?;
 
-            let mut frs = vec![<Fr as Field>::zero(); num_hashes];
+            let mut frs = vec![F::zero(); num_hashes];
             program.read_into_buffer(&result_buffer, &mut frs)?;
             Ok(frs.to_vec())
         });
@@ -228,6 +234,7 @@ fn calc_global_work_size(batch_size: usize, local_work_size: usize) -> usize {
 mod test {
     use super::*;
     use crate::poseidon::{Poseidon, SimplePoseidonBatchHasher};
+    use blstrs::Scalar as Fr;
     use generic_array::sequence::GenericSequence;
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
@@ -241,9 +248,10 @@ mod test {
         let batch_size = 1025;
 
         let mut cl_hasher =
-            ClBatchHasher::<U2>::new_with_strength(device, Strength::Standard, batch_size).unwrap();
+            ClBatchHasher::<Fr, U2>::new_with_strength(device, Strength::Standard, batch_size)
+                .unwrap();
         let mut simple_hasher =
-            SimplePoseidonBatchHasher::<U2>::new_with_strength(Strength::Standard, batch_size);
+            SimplePoseidonBatchHasher::<Fr, U2>::new_with_strength(Strength::Standard, batch_size);
 
         let preimages = (0..batch_size)
             .map(|_| GenericArray::<Fr, U2>::generate(|_| Fr::random(&mut rng)))

--- a/src/proteus/program.rs
+++ b/src/proteus/program.rs
@@ -15,10 +15,7 @@ use crate::proteus::sources;
 ///
 /// If the device supports CUDA, then CUDA is used, else OpenCL. You can force a selection with
 /// the environment variable `NEPTUNE_GPU_FRAMEWORK`, which can be set either to `cuda` or `opencl`.
-pub fn program<Fr>(device: &Device) -> Result<Program, Error>
-where
-    Fr: GpuField,
-{
+pub fn program(device: &Device) -> Result<Program, Error> {
     let framework = match env::var("NEPTUNE_GPU_FRAMEWORK") {
         Ok(env) => match env.as_ref() {
             "cuda" => {
@@ -43,14 +40,11 @@ where
         },
         Err(_) => device.framework(),
     };
-    program_use_framework::<Fr>(device, &framework)
+    program_use_framework(device, &framework)
 }
 
 /// Returns the program for the specified [`rust_gpu_tools::device::Framework`].
-pub fn program_use_framework<Fr>(device: &Device, framework: &Framework) -> Result<Program, Error>
-where
-    Fr: GpuField,
-{
+pub fn program_use_framework(device: &Device, framework: &Framework) -> Result<Program, Error> {
     match framework {
         #[cfg(feature = "cuda")]
         Framework::Cuda => {
@@ -66,7 +60,7 @@ where
         #[cfg(feature = "opencl")]
         Framework::Opencl => {
             info!("Using kernel on OpenCL.");
-            let src = sources::generate_program::<Fr, ec_gpu_gen::Limb64>();
+            let src = sources::generate_program::<ec_gpu_gen::Limb64>();
             let opencl_device = device
                 .opencl_device()
                 .ok_or(Error::ClError(ClError::DeviceNotFound))?;


### PR DESCRIPTION
It is now possible to use Neptune with Pasta curves on the GPU. In
order to make that possible, two new compile-time features are introduced.
`bls` to use BLS12-381 and `pasta` to use the Pasta curves (Pallas and
Vesta).

BREAKING CHANGE: The API now requires to pass in the field that
should be used. It does no longer default to BLS12-381.

If the GPU is used (enabled by the `cuda` and/or `opencl` features), you
now also need to specify the supported fields, `bls` and/or `pasta`.