### PR TITLE
refactor: use field name as part of the function names

### DIFF
--- a/src/proteus/cl/poseidon.cl
+++ b/src/proteus/cl/poseidon.cl
@@ -1,15 +1,15 @@
-typedef struct state_{arity}_{strength} {{
+typedef struct state_{field}_{arity}_{strength} {{
   {field} elements[{width}];
   int current_round;
   int rk_offset;
-}} state_{arity}_{strength};
+}} state_{field}_{arity}_{strength};
 
-DEVICE state_{arity}_{strength} add_round_key_{arity}_{strength} (CONSTANT {field} constants[{constants_elements}], state_{arity}_{strength} s, int i) {{
+DEVICE state_{field}_{arity}_{strength} add_round_key_{field}_{arity}_{strength} (CONSTANT {field} constants[{constants_elements}], state_{field}_{arity}_{strength} s, int i) {{
     s.elements[i] = {field}_add(s.elements[i], (constants + {round_keys_offset})[s.rk_offset + i]);
     return s;
 }}
 
-DEVICE state_{arity}_{strength} apply_matrix_{arity}_{strength} (CONSTANT {field} matrix[{width}][{width}], state_{arity}_{strength} s) {{
+DEVICE state_{field}_{arity}_{strength} apply_matrix_{field}_{arity}_{strength} (CONSTANT {field} matrix[{width}][{width}], state_{field}_{arity}_{strength} s) {{
     {field} tmp[{width}];
     for (int i = 0; i < {width}; ++i) {{
         tmp[i] = s.elements[i];
@@ -24,7 +24,7 @@ DEVICE state_{arity}_{strength} apply_matrix_{arity}_{strength} (CONSTANT {field
     return s;
   }}
 
-DEVICE state_{arity}_{strength} apply_sparse_matrix_{arity}_{strength} (CONSTANT {field} sm[{sparse_matrix_size}], state_{arity}_{strength} s) {{
+DEVICE state_{field}_{arity}_{strength} apply_sparse_matrix_{field}_{arity}_{strength} (CONSTANT {field} sm[{sparse_matrix_size}], state_{field}_{arity}_{strength} s) {{
     {field} first_elt = s.elements[0];
 
     s.elements[0] = scalar_product(sm + {w_hat_offset}, s.elements, {width});
@@ -37,78 +37,78 @@ DEVICE state_{arity}_{strength} apply_sparse_matrix_{arity}_{strength} (CONSTANT
     return s;
   }}
 
-DEVICE state_{arity}_{strength} apply_round_matrix_{arity}_{strength} (CONSTANT {field} constants[{constants_elements}], state_{arity}_{strength} s) {{
+DEVICE state_{field}_{arity}_{strength} apply_round_matrix_{field}_{arity}_{strength} (CONSTANT {field} constants[{constants_elements}], state_{field}_{arity}_{strength} s) {{
     if (s.current_round == {sparse_offset}) {{
-        s = apply_matrix_{arity}_{strength}((CONSTANT {field} (*)[{width}])(constants + {pre_sparse_matrix_offset}), s);
+        s = apply_matrix_{field}_{arity}_{strength}((CONSTANT {field} (*)[{width}])(constants + {pre_sparse_matrix_offset}), s);
       }} else if ((s.current_round > {sparse_offset}) && (s.current_round < {full_half} + {partial_rounds})) {{
         int index = s.current_round - {sparse_offset} - 1;
-        s = apply_sparse_matrix_{arity}_{strength}(constants + {sparse_matrixes_offset} + (index * {sparse_matrix_size}), s);
+        s = apply_sparse_matrix_{field}_{arity}_{strength}(constants + {sparse_matrixes_offset} + (index * {sparse_matrix_size}), s);
       }} else {{
-        s = apply_matrix_{arity}_{strength}((CONSTANT {field} (*)[{width}])(constants + {mds_matrix_offset}), s);
+        s = apply_matrix_{field}_{arity}_{strength}((CONSTANT {field} (*)[{width}])(constants + {mds_matrix_offset}), s);
       }}
     return s;
   }}
 
-DEVICE state_{arity}_{strength} add_full_round_keys_{arity}_{strength} (CONSTANT {field} constants[{constants_elements}], state_{arity}_{strength} s) {{
+DEVICE state_{field}_{arity}_{strength} add_full_round_keys_{field}_{arity}_{strength} (CONSTANT {field} constants[{constants_elements}], state_{field}_{arity}_{strength} s) {{
     for (int i = 0; i < {width}; ++i) {{
-        s = add_round_key_{arity}_{strength}(constants, s, i);
+        s = add_round_key_{field}_{arity}_{strength}(constants, s, i);
       }}
     s.rk_offset += {width};
     return s;
   }}
 
 /* Unused, kept for completeness
-DEVICE state_{arity}_{strength} add_partial_round_key_{arity}_{strength} (CONSTANT {field} constants[{constants_elements}], state_{arity}_{strength} s) {{
-    s = add_round_key_{arity}_{strength}(constants, s, 0);
+DEVICE state_{field}_{arity}_{strength} add_partial_round_key_{field}_{arity}_{strength} (CONSTANT {field} constants[{constants_elements}], state_{field}_{arity}_{strength} s) {{
+    s = add_round_key_{field}_{arity}_{strength}(constants, s, 0);
     s.rk_offset += 1;
     return s;
 }}
 */
 
-DEVICE state_{arity}_{strength} full_round_{arity}_{strength} (CONSTANT {field} constants[{constants_elements}], state_{arity}_{strength} s) {{
+DEVICE state_{field}_{arity}_{strength} full_round_{field}_{arity}_{strength} (CONSTANT {field} constants[{constants_elements}], state_{field}_{arity}_{strength} s) {{
     for (int i = 0; i < {width}; ++i) {{
         s.elements[i] = quintic_s_box(s.elements[i], {field}_ZERO, (constants + {round_keys_offset})[s.rk_offset + i]);
       }}
     s.rk_offset += {width};
-    s = apply_round_matrix_{arity}_{strength}(constants, s);
+    s = apply_round_matrix_{field}_{arity}_{strength}(constants, s);
     s.current_round += 1;
     return s;
 }}
 
-DEVICE state_{arity}_{strength} last_full_round_{arity}_{strength} (CONSTANT {field} constants[{constants_elements}], state_{arity}_{strength} s) {{
+DEVICE state_{field}_{arity}_{strength} last_full_round_{field}_{arity}_{strength} (CONSTANT {field} constants[{constants_elements}], state_{field}_{arity}_{strength} s) {{
     for (int i = 0; i < {width}; ++i) {{
         s.elements[i] = quintic_s_box(s.elements[i], {field}_ZERO, {field}_ZERO);
       }}
-    s = apply_round_matrix_{arity}_{strength}(constants, s);
+    s = apply_round_matrix_{field}_{arity}_{strength}(constants, s);
     return s;
 }}
 
-DEVICE state_{arity}_{strength} partial_round_{arity}_{strength} (CONSTANT {field} constants[{constants_elements}], state_{arity}_{strength} s) {{
+DEVICE state_{field}_{arity}_{strength} partial_round_{field}_{arity}_{strength} (CONSTANT {field} constants[{constants_elements}], state_{field}_{arity}_{strength} s) {{
     s.elements[0] = quintic_s_box(s.elements[0], {field}_ZERO, (constants + {round_keys_offset})[s.rk_offset]);
     s.rk_offset += 1;
-    s = apply_round_matrix_{arity}_{strength}(constants, s);
+    s = apply_round_matrix_{field}_{arity}_{strength}(constants, s);
     s.current_round += 1;
     return s;
 }}
 
-DEVICE state_{arity}_{strength} hash_{arity}_{strength} (CONSTANT {field} constants[{constants_elements}], state_{arity}_{strength} s) {{
-    s = add_full_round_keys_{arity}_{strength}(constants, s);
+DEVICE state_{field}_{arity}_{strength} hash_{field}_{arity}_{strength} (CONSTANT {field} constants[{constants_elements}], state_{field}_{arity}_{strength} s) {{
+    s = add_full_round_keys_{field}_{arity}_{strength}(constants, s);
 
     for (int i = 0; i < {full_half}; ++i) {{
-        s = full_round_{arity}_{strength}(constants, s);
+        s = full_round_{field}_{arity}_{strength}(constants, s);
       }}
     for (int i = 0; i < {partial_rounds}; ++ i) {{
-        s = partial_round_{arity}_{strength}(constants, s);
+        s = partial_round_{field}_{arity}_{strength}(constants, s);
       }}
     for (int i = 0; i < ({full_half} - 1); ++ i) {{
-        s = full_round_{arity}_{strength}(constants, s);
+        s = full_round_{field}_{arity}_{strength}(constants, s);
       }}
-    s = last_full_round_{arity}_{strength}(constants, s);
+    s = last_full_round_{field}_{arity}_{strength}(constants, s);
 
     return s;
   }}
 
-KERNEL void hash_preimages_{arity}_{strength}(CONSTANT {field} constants[{constants_elements}],
+KERNEL void hash_preimages_{field}_{arity}_{strength}(CONSTANT {field} constants[{constants_elements}],
                              GLOBAL {field} *preimages,
                              GLOBAL {field} *digests,
                              int batch_size
@@ -118,7 +118,7 @@ KERNEL void hash_preimages_{arity}_{strength}(CONSTANT {field} constants[{consta
     if (global_id < batch_size) {{
         int offset = global_id * {arity};
 
-        state_{arity}_{strength} s;
+        state_{field}_{arity}_{strength} s;
         s.elements[0] = constants[{domain_tag_offset}];
         for (int i = 0; i < {arity}; ++i) {{
             s.elements[i+1] = preimages[offset + i];
@@ -126,7 +126,7 @@ KERNEL void hash_preimages_{arity}_{strength}(CONSTANT {field} constants[{consta
         s.current_round = 0;
         s.rk_offset = 0;
 
-        s = hash_{arity}_{strength}(constants, s);
+        s = hash_{field}_{arity}_{strength}(constants, s);
 
         digests[global_id] = s.elements[1];
       }}

--- a/src/proteus/gpu.rs
+++ b/src/proteus/gpu.rs
@@ -161,33 +161,33 @@ where
 
         let kernel_name = match (A::to_usize(), self.constants.strength()) {
             #[cfg(feature = "arity2")]
-            (2, Strength::Standard) => "hash_preimages_2_standard",
+            (2, Strength::Standard) => "hash_preimages_Fr_2_standard",
             #[cfg(all(feature = "arity2", feature = "strengthened"))]
-            (2, Strength::Strengthened) => "hash_preimages_2_strengthened",
+            (2, Strength::Strengthened) => "hash_preimages_Fr_2_strengthened",
             #[cfg(feature = "arity4")]
-            (4, Strength::Standard) => "hash_preimages_4_standard",
+            (4, Strength::Standard) => "hash_preimages_Fr_4_standard",
             #[cfg(all(feature = "arity4", feature = "strengthened"))]
-            (4, Strength::Strengthened) => "hash_preimages_4_strengthened",
+            (4, Strength::Strengthened) => "hash_preimages_Fr_4_strengthened",
             #[cfg(feature = "arity8")]
-            (8, Strength::Standard) => "hash_preimages_8_standard",
+            (8, Strength::Standard) => "hash_preimages_Fr_8_standard",
             #[cfg(all(feature = "arity8", feature = "strengthened"))]
-            (8, Strength::Strengthened) => "hash_preimages_8_strengthened",
+            (8, Strength::Strengthened) => "hash_preimages_Fr_8_strengthened",
             #[cfg(feature = "arity11")]
-            (11, Strength::Standard) => "hash_preimages_11_standard",
+            (11, Strength::Standard) => "hash_preimages_Fr_11_standard",
             #[cfg(all(feature = "arity11", feature = "strengthened"))]
-            (11, Strength::Strengthened) => "hash_preimages_11_strengthened",
+            (11, Strength::Strengthened) => "hash_preimages_Fr_11_strengthened",
             #[cfg(feature = "arity16")]
-            (16, Strength::Standard) => "hash_preimages_16_standard",
+            (16, Strength::Standard) => "hash_preimages_Fr_16_standard",
             #[cfg(all(feature = "arity16", feature = "strengthened"))]
-            (16, Strength::Strengthened) => "hash_preimages_16_strengthened",
+            (16, Strength::Strengthened) => "hash_preimages_Fr_16_strengthened",
             #[cfg(feature = "arity24")]
-            (24, Strength::Standard) => "hash_preimages_24_standard",
+            (24, Strength::Standard) => "hash_preimages_Fr_24_standard",
             #[cfg(all(feature = "arity24", feature = "strengthened"))]
-            (24, Strength::Strengthened) => "hash_preimages_24_strengthened",
+            (24, Strength::Strengthened) => "hash_preimages_Fr_24_strengthened",
             #[cfg(feature = "arity36")]
-            (36, Strength::Standard) => "hash_preimages_36_standard",
+            (36, Strength::Standard) => "hash_preimages_Fr_36_standard",
             #[cfg(all(feature = "arity36", feature = "strengthened"))]
-            (36, Strength::Strengthened) => "hash_preimages_36_strengthened",
+            (36, Strength::Strengthened) => "hash_preimages_Fr_36_strengthened",
             (arity, strength) => return Err(Error::GpuError(format!("No kernel for arity {} and strength {:?} available. Try to enable the `arity{}` feature flag.", arity, strength, arity))),
         };
 


### PR DESCRIPTION
This is in preparation for supporting fields other than BLS12-381.
Make the field name part of all kernel functions.

Part of #130.