### PR TITLE
Implement Arity for U1.

### DIFF
--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -44,6 +44,7 @@ impl<F: PrimeField> Arity<F> for U0 {
 }
 
 impl_arity!(
+    U1 => U2,
     U2 => U3,
     U3 => U4,
     U4 => U5,


### PR DESCRIPTION
It makes sense semantically to specify `U1` in a downstream usage. In point of fact, it will be optimized away, but without U1 implementing Arity, there is no good way to signal this case generically.