### PR TITLE
Reduce constraints.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://book.async.rs/overview
 
 ## Unreleased
 
+## 6.2.1 - 2022-6-10
+- Reduce constraints (https://github.com/filecoin-project/neptune/pull/148)
+
 ## 6.1.1 - 2022-5-26
 - Implement Arity for U1 (https://github.com/filecoin-project/neptune/pull/145)
 

--- a/benches/synthesis.rs
+++ b/benches/synthesis.rs
@@ -61,7 +61,7 @@ where
                         let mut cs = BenchCS::<Fr>::new();
                         let circuit = BenchCircuit::<A> {
                             n: *n,
-                            circuit_type: circuit_type,
+                            circuit_type,
                             _a: PhantomData::<A>,
                         };
                         circuit.synthesize(&mut cs)

--- a/benches/synthesis.rs
+++ b/benches/synthesis.rs
@@ -6,17 +6,18 @@ use blstrs::Scalar as Fr;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use ff::Field;
 use generic_array::typenum;
-use neptune::circuit::poseidon_hash;
+use neptune::circuit::{poseidon_hash_circuit, CircuitType};
 use neptune::*;
 use rand::thread_rng;
 use std::marker::PhantomData;
 
-struct BenchCircuit<A: Arity<Fr>> {
+struct BenchCircuit<'a, A: Arity<Fr>> {
     n: usize,
+    circuit_type: &'a CircuitType,
     _a: PhantomData<A>,
 }
 
-impl<A: Arity<Fr>> Circuit<Fr> for BenchCircuit<A> {
+impl<A: Arity<Fr>> Circuit<Fr> for BenchCircuit<'_, A> {
     fn synthesize<CS: ConstraintSystem<Fr>>(self, mut cs: &mut CS) -> Result<(), SynthesisError> {
         let mut rng = thread_rng();
         let arity = A::to_usize();
@@ -34,7 +35,8 @@ impl<A: Arity<Fr>> Circuit<Fr> for BenchCircuit<A> {
                     AllocatedNum::alloc(cs.namespace(|| format!("data {}", i)), || Ok(fr)).unwrap()
                 })
                 .collect::<Vec<_>>();
-            let _ = poseidon_hash(&mut cs, data, &constants).expect("poseidon hashing failed");
+            let _ = poseidon_hash_circuit(&mut cs, *self.circuit_type, data, &constants)
+                .expect("poseidon hashing failed");
         }
         Ok(())
     }
@@ -45,28 +47,29 @@ where
     A: Arity<Fr>,
 {
     let mut group = c.benchmark_group(format!("synthesis-{}", A::to_usize()));
-
-    let mut num_hashes = 1;
-
-    for _ in 0..4 {
-        group.bench_with_input(
-            BenchmarkId::new(
-                "Poseidon Synthesis",
-                format!("arity: {}, count: {}", A::to_usize(), num_hashes),
-            ),
-            &num_hashes,
-            |b, n| {
-                b.iter(|| {
-                    let mut cs = BenchCS::<Fr>::new();
-                    let circuit = BenchCircuit::<A> {
-                        n: *n,
-                        _a: PhantomData::<A>,
-                    };
-                    circuit.synthesize(&mut cs)
-                })
-            },
-        );
-        num_hashes *= 10;
+    for i in 0..4 {
+        let num_hashes = 10usize.pow(i);
+        for circuit_type in &[CircuitType::Legacy, CircuitType::OptimalAllocated] {
+            group.bench_with_input(
+                BenchmarkId::new(
+                    circuit_type.label(),
+                    format!("arity: {}, count: {}", A::to_usize(), num_hashes),
+                ),
+                &num_hashes,
+                |b, n| {
+                    b.iter(|| {
+                        let mut cs = BenchCS::<Fr>::new();
+                        let circuit = BenchCircuit::<A> {
+                            n: *n,
+                            circuit_type: circuit_type,
+                            _a: PhantomData::<A>,
+                        };
+                        circuit.synthesize(&mut cs)
+                    })
+                },
+            );
+        }
+        // num_hashes *= 10;
     }
 }
 

--- a/src/circuit2.rs
+++ b/src/circuit2.rs
@@ -1,3 +1,4 @@
+/// The `circuit2` module implements the optimal Poseidon hash circuit.
 use std::ops::{AddAssign, MulAssign};
 
 use crate::hash_type::HashType;
@@ -387,7 +388,7 @@ where
     }
 }
 
-/// Create circuit for Poseidon hash.
+/// Create circuit for Poseidon hash, returning an unallocated `Num` at the cost of one constraint.
 pub fn poseidon_hash_allocated<CS, Scalar, A>(
     mut cs: CS,
     preimage: Vec<AllocatedNum<Scalar>>,
@@ -421,7 +422,7 @@ where
     p.hash_to_allocated(cs)
 }
 
-/// Create circuit for Poseidon hash.
+/// Create circuit for Poseidon hash, minimizing constraints by returning an unallocated `Num`.
 pub fn poseidon_hash_num<CS, Scalar, A>(
     mut cs: CS,
     preimage: Vec<AllocatedNum<Scalar>>,

--- a/src/circuit2.rs
+++ b/src/circuit2.rs
@@ -121,12 +121,10 @@ impl<Scalar: PrimeField> Elt<Scalar> {
     }
 
     fn num(&self) -> num::Num<Scalar> {
-        let num = match self {
+        match self {
             Elt::Num(num) => num.clone(),
             Elt::Allocated(a) => a.clone().into(),
-        };
-
-        num
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ compile_error!("The `strengthened` feature needs the `cuda` and/or `opencl` feat
 
 /// Poseidon circuit
 pub mod circuit;
+pub mod circuit2;
 pub mod error;
 mod matrix;
 mod mds;


### PR DESCRIPTION
It came to my attention (cc: @BoyuanFeng) that our circuit uses more than the expected minimum number of constraints. I tracked this down to an extra constraint per round because we were converting linear combinations to allocated nums *before* applying the s-box — when in fact we can afford to wait until after.

With this fix applied, we now have 2 fewer than the 'expected' number. This is because we save 3 constraints by noting that the very first s-box applied to the constant domain tag has constant output. Then we have one extra constraint because we chose to allocate the final result.

This will be a breaking change to circuits, so we may need to provide backwards compatibility. I'm not 100% sure what the smoothest way to accomplish that will be, but this PR can be reviewed for correctness of the 'optimization' first.

Alternately, we could consider making this change opt-in at runtime, perhaps by a new entry point. (This might also return an unallocated result, for that sweet final constraint reduction.)

Before:
```
        test_poseidon_hash_aux::<typenum::U2>(Strength::Standard, 311, false);
        test_poseidon_hash_aux::<typenum::U4>(Strength::Standard, 377, false);
        test_poseidon_hash_aux::<typenum::U8>(Strength::Standard, 505, false);
        test_poseidon_hash_aux::<typenum::U16>(Strength::Standard, 761, false);
        test_poseidon_hash_aux::<typenum::U24>(Strength::Standard, 1009, false);
        test_poseidon_hash_aux::<typenum::U36>(Strength::Standard, 1385, false);

        test_poseidon_hash_aux::<typenum::U2>(Strength::Strengthened, 367, false);
        test_poseidon_hash_aux::<typenum::U4>(Strength::Strengthened, 433, false);
        test_poseidon_hash_aux::<typenum::U8>(Strength::Strengthened, 565, false);
        test_poseidon_hash_aux::<typenum::U16>(Strength::Strengthened, 821, false);
        test_poseidon_hash_aux::<typenum::U24>(Strength::Strengthened, 1069, false);
        test_poseidon_hash_aux::<typenum::U36>(Strength::Strengthened, 1445, false);
```

After:
```
        test_poseidon_hash_aux::<typenum::U2>(Strength::Standard, 235, false);
        test_poseidon_hash_aux::<typenum::U4>(Strength::Standard, 286, false);
        test_poseidon_hash_aux::<typenum::U8>(Strength::Standard, 385, false);
        test_poseidon_hash_aux::<typenum::U16>(Strength::Standard, 583, false);
        test_poseidon_hash_aux::<typenum::U24>(Strength::Standard, 775, false);
        test_poseidon_hash_aux::<typenum::U32>(Strength::Standard, 970, false);
        test_poseidon_hash_aux::<typenum::U36>(Strength::Standard, 1066, false);

        test_poseidon_hash_aux::<typenum::U2>(Strength::Strengthened, 277, false);
        test_poseidon_hash_aux::<typenum::U4>(Strength::Strengthened, 328, false);
        test_poseidon_hash_aux::<typenum::U8>(Strength::Strengthened, 430, false);
        test_poseidon_hash_aux::<typenum::U16>(Strength::Strengthened, 628, false);
        test_poseidon_hash_aux::<typenum::U24>(Strength::Strengthened, 820, false);
        test_poseidon_hash_aux::<typenum::U32>(Strength::Strengthened, 1015, false);
        test_poseidon_hash_aux::<typenum::U36>(Strength::Strengthened, 1111, false);
```