### PR TITLE
Add sponge circuit synthesis test and remove make_elt method.

### DIFF
--- a/src/sponge/vanilla.rs
+++ b/src/sponge/vanilla.rs
@@ -98,6 +98,7 @@ where
     fn element(&self, index: usize) -> Self::Elt;
     fn set_element(&mut self, index: usize, elt: Self::Elt);
 
+    /// `make_elt` is deprecated and will be removed. Do not use.
     fn make_elt(&self, val: F, acc: &mut Self::Acc) -> Self::Elt;
 
     fn is_simplex(&self) -> bool {


### PR DESCRIPTION
The initial implementation of `SpongeCircuit::start()` used `make_elt` to construct the tag, and this resulted in an allocated num in the circuit. Really the tag should not be allocated. This all makes clear that the `SpongeTrait::make_elt` was an unnecessary and bad idea. This PR adds a test (which initially failed), modifies the implementation so the test passes, and adds a comment deprecating `SpongeTrait::make_elt`. I would have removed the method entirely, but I'd like to make a patch release with this fix so technically shouldn't alter the API.