### PR TITLE
Sponge absorb add

### DIFF
--- a/src/circuit2.rs
+++ b/src/circuit2.rs
@@ -292,14 +292,7 @@ where
             };
 
             if first_round {
-                if i == 0 {
-                    // The very first s-box for the constant arity tag can also be computed statically, as a constant.
-                    self.elements[i] = constant_quintic_s_box_pre_add_tag::<CS, Scalar>(
-                        &self.elements[i],
-                        pre_round_key,
-                        post_round_key,
-                    );
-                } else {
+                {
                     self.elements[i] = quintic_s_box_pre_add(
                         cs.namespace(|| format!("quintic s-box {}", i)),
                         &self.elements[i],
@@ -564,7 +557,7 @@ fn constant_quintic_s_box_pre_add_tag<CS: ConstraintSystem<Scalar>, Scalar: Prim
     let mut tag = tag.val().expect("missing tag val");
     pre_round_key.expect("pre_round_key must be provided");
     post_round_key.expect("post_round_key must be provided");
-
+    dbg!(tag);
     crate::quintic_s_box::<Scalar>(&mut tag, pre_round_key.as_ref(), post_round_key.as_ref());
 
     Elt::num_from_fr::<CS>(tag)
@@ -731,23 +724,23 @@ mod tests {
 
     #[test]
     fn test_poseidon_hash() {
-        test_poseidon_hash_aux::<typenum::U2>(Strength::Standard, 234, false);
-        test_poseidon_hash_aux::<typenum::U4>(Strength::Standard, 285, false);
-        test_poseidon_hash_aux::<typenum::U8>(Strength::Standard, 384, false);
-        test_poseidon_hash_aux::<typenum::U16>(Strength::Standard, 582, false);
-        test_poseidon_hash_aux::<typenum::U24>(Strength::Standard, 774, false);
-        test_poseidon_hash_aux::<typenum::U32>(Strength::Standard, 969, false);
-        test_poseidon_hash_aux::<typenum::U36>(Strength::Standard, 1065, false);
+        test_poseidon_hash_aux::<typenum::U2>(Strength::Standard, 237, false);
+        test_poseidon_hash_aux::<typenum::U4>(Strength::Standard, 288, false);
+        test_poseidon_hash_aux::<typenum::U8>(Strength::Standard, 387, false);
+        test_poseidon_hash_aux::<typenum::U16>(Strength::Standard, 585, false);
+        test_poseidon_hash_aux::<typenum::U24>(Strength::Standard, 777, false);
+        test_poseidon_hash_aux::<typenum::U32>(Strength::Standard, 972, false);
+        test_poseidon_hash_aux::<typenum::U36>(Strength::Standard, 1068, false);
 
-        test_poseidon_hash_aux::<typenum::U2>(Strength::Strengthened, 276, false);
-        test_poseidon_hash_aux::<typenum::U4>(Strength::Strengthened, 327, false);
-        test_poseidon_hash_aux::<typenum::U8>(Strength::Strengthened, 429, false);
-        test_poseidon_hash_aux::<typenum::U16>(Strength::Strengthened, 627, false);
-        test_poseidon_hash_aux::<typenum::U24>(Strength::Strengthened, 819, false);
-        test_poseidon_hash_aux::<typenum::U32>(Strength::Strengthened, 1014, false);
-        test_poseidon_hash_aux::<typenum::U36>(Strength::Strengthened, 1110, false);
+        test_poseidon_hash_aux::<typenum::U2>(Strength::Strengthened, 279, false);
+        test_poseidon_hash_aux::<typenum::U4>(Strength::Strengthened, 330, false);
+        test_poseidon_hash_aux::<typenum::U8>(Strength::Strengthened, 432, false);
+        test_poseidon_hash_aux::<typenum::U16>(Strength::Strengthened, 630, false);
+        test_poseidon_hash_aux::<typenum::U24>(Strength::Strengthened, 822, false);
+        test_poseidon_hash_aux::<typenum::U32>(Strength::Strengthened, 1017, false);
+        test_poseidon_hash_aux::<typenum::U36>(Strength::Strengthened, 1113, false);
 
-        test_poseidon_hash_aux::<typenum::U15>(Strength::Standard, 558, true);
+        test_poseidon_hash_aux::<typenum::U15>(Strength::Standard, 561, true);
     }
 
     fn test_poseidon_hash_aux<A>(
@@ -783,13 +776,11 @@ mod tests {
             let expected_constraints_calculated = {
                 let width = 1 + arity;
                 let s_box_cost = 3;
-                let savings_from_domain_tag_sbox = s_box_cost; // The very first s-box output is constant.
 
                 let base_expected_constraints = (width * s_box_cost * constants.full_rounds)
                     + (s_box_cost * constants.partial_rounds);
-                let adjustment = savings_from_domain_tag_sbox;
 
-                base_expected_constraints - adjustment
+                base_expected_constraints
             };
 
             let mut data = |cs: &mut TestConstraintSystem<Fr>, fr_data: &mut [Fr]| {

--- a/src/circuit2.rs
+++ b/src/circuit2.rs
@@ -548,21 +548,6 @@ fn quintic_s_box_pre_add<CS: ConstraintSystem<Scalar>, Scalar: PrimeField>(
     }
 }
 
-/// Compute l^5 and enforce constraint. If round_key is supplied, add it to l first.
-fn constant_quintic_s_box_pre_add_tag<CS: ConstraintSystem<Scalar>, Scalar: PrimeField>(
-    tag: &Elt<Scalar>,
-    pre_round_key: Option<Scalar>,
-    post_round_key: Option<Scalar>,
-) -> Elt<Scalar> {
-    let mut tag = tag.val().expect("missing tag val");
-    pre_round_key.expect("pre_round_key must be provided");
-    post_round_key.expect("post_round_key must be provided");
-    dbg!(tag);
-    crate::quintic_s_box::<Scalar>(&mut tag, pre_round_key.as_ref(), post_round_key.as_ref());
-
-    Elt::num_from_fr::<CS>(tag)
-}
-
 /// Calculates square of sum and enforces that constraint.
 pub fn square_sum<CS: ConstraintSystem<Scalar>, Scalar: PrimeField>(
     mut cs: CS,

--- a/src/circuit2.rs
+++ b/src/circuit2.rs
@@ -87,6 +87,13 @@ impl<Scalar: PrimeField> Elt<Scalar> {
         }
     }
 
+    pub fn add_ref(self, other: &Elt<Scalar>) -> Result<Elt<Scalar>, SynthesisError> {
+        match (self, other) {
+            (Elt::Num(a), Elt::Num(b)) => Ok(Elt::Num(a.add(b))),
+            (a, b) => Ok(Elt::Num(a.num().add(&b.num()))),
+        }
+    }
+
     /// Scale
     pub fn scale<CS: ConstraintSystem<Scalar>>(
         self,

--- a/src/circuit2.rs
+++ b/src/circuit2.rs
@@ -762,10 +762,8 @@ mod tests {
                 let width = 1 + arity;
                 let s_box_cost = 3;
 
-                let base_expected_constraints = (width * s_box_cost * constants.full_rounds)
-                    + (s_box_cost * constants.partial_rounds);
-
-                base_expected_constraints
+                (width * s_box_cost * constants.full_rounds)
+                    + (s_box_cost * constants.partial_rounds)
             };
 
             let mut data = |cs: &mut TestConstraintSystem<Fr>, fr_data: &mut [Fr]| {

--- a/src/sponge/api.rs
+++ b/src/sponge/api.rs
@@ -187,6 +187,8 @@ pub trait InnerSpongeAPI<F: PrimeField, A: Arity<F>> {
     fn set_absorb_pos(&mut self, pos: usize);
     fn set_squeeze_pos(&mut self, pos: usize);
 
+    fn add(a: Self::Value, b: &Self::Value) -> Self::Value;
+
     fn initialize_hasher(&mut self);
     fn update_hasher(&mut self, op: SpongeOp);
     fn finalize_hasher(&mut self) -> u128;
@@ -221,7 +223,8 @@ impl<F: PrimeField, A: Arity<F>, S: InnerSpongeAPI<F, A>> SpongeAPI<F, A> for S 
                 self.permute(acc);
                 self.set_absorb_pos(0);
             }
-            self.write_rate_element(self.absorb_pos(), element);
+            let old = self.read_rate_element(self.absorb_pos());
+            self.write_rate_element(self.absorb_pos(), &S::add(old, element));
             self.set_absorb_pos(self.absorb_pos() + 1);
         }
         self.set_squeeze_pos(rate);

--- a/src/sponge/api.rs
+++ b/src/sponge/api.rs
@@ -220,6 +220,7 @@ impl<F: PrimeField, A: Arity<F>, S: InnerSpongeAPI<F, A>> SpongeAPI<F, A> for S 
 
         for element in elements.iter() {
             if self.absorb_pos() == rate {
+                dbg!("permute in absorb");
                 self.permute(acc);
                 self.set_absorb_pos(0);
             }
@@ -238,6 +239,7 @@ impl<F: PrimeField, A: Arity<F>, S: InnerSpongeAPI<F, A>> SpongeAPI<F, A> for S 
 
         for _ in 0..length {
             if self.squeeze_pos() == rate {
+                dbg!("permute in squeeze");
                 self.permute(acc);
                 self.set_squeeze_pos(0);
                 self.set_absorb_pos(0);

--- a/src/sponge/api.rs
+++ b/src/sponge/api.rs
@@ -225,7 +225,6 @@ impl<F: PrimeField, A: Arity<F>, S: InnerSpongeAPI<F, A>> SpongeAPI<F, A> for S 
 
         for element in elements.iter() {
             if self.absorb_pos() == rate {
-                dbg!("permute in absorb");
                 self.permute(acc);
                 self.set_absorb_pos(0);
             }
@@ -244,7 +243,6 @@ impl<F: PrimeField, A: Arity<F>, S: InnerSpongeAPI<F, A>> SpongeAPI<F, A> for S 
 
         for _ in 0..length {
             if self.squeeze_pos() == rate {
-                dbg!("permute in squeeze");
                 self.permute(acc);
                 self.set_squeeze_pos(0);
                 self.set_absorb_pos(0);

--- a/src/sponge/circuit.rs
+++ b/src/sponge/circuit.rs
@@ -132,6 +132,8 @@ impl<'a, F: PrimeField, A: Arity<F>, CS: 'a + ConstraintSystem<F>> SpongeTrait<'
         self.permutation_count += 1;
         self.state
             .hash(&mut ns.namespace(|| format!("permutation {}", self.permutation_count)))?;
+        dbg!("permute_state");
+
         Ok(())
     }
 
@@ -295,7 +297,7 @@ mod tests {
             .zip(&allocated_result)
             .all(|(a, b)| *a == b.val().unwrap());
 
-        let permutation_constraints = 285; // For U4.
+        let permutation_constraints = 288; // For U4.
         let permutations_per_direction = (n - 1) / A::to_usize();
         let final_absorption_permutation = 1;
         let expected_permutations = 2 * permutations_per_direction + final_absorption_permutation;

--- a/src/sponge/circuit.rs
+++ b/src/sponge/circuit.rs
@@ -152,7 +152,7 @@ impl<'a, F: PrimeField, A: Arity<F>, CS: 'a + ConstraintSystem<F>> SpongeTrait<'
     fn absorb_aux(&mut self, elt: &Self::Elt) -> Self::Elt {
         // Elt::add always returns `Ok`, so `unwrap` is safe.
         self.element(SpongeTrait::absorb_pos(self) + SpongeTrait::capacity(self))
-            .add(elt.clone())
+            .add_ref(elt)
             .unwrap()
     }
 
@@ -213,6 +213,9 @@ impl<'a, F: PrimeField, A: Arity<F>, CS: 'a + ConstraintSystem<F>> InnerSpongeAP
     }
     fn set_squeeze_pos(&mut self, pos: usize) {
         SpongeTrait::set_squeeze_pos(self, pos);
+    }
+    fn add(a: Elt<F>, b: &Elt<F>) -> Elt<F> {
+        a.add_ref(b).unwrap()
     }
 
     fn initialize_hasher(&mut self) {

--- a/src/sponge/circuit.rs
+++ b/src/sponge/circuit.rs
@@ -132,7 +132,6 @@ impl<'a, F: PrimeField, A: Arity<F>, CS: 'a + ConstraintSystem<F>> SpongeTrait<'
         self.permutation_count += 1;
         self.state
             .hash(&mut ns.namespace(|| format!("permutation {}", self.permutation_count)))?;
-        dbg!("permute_state");
 
         Ok(())
     }
@@ -586,11 +585,6 @@ mod tests {
 
             sponge.finish(acc).unwrap();
 
-            dbg!(
-                &expected_permutations,
-                &expected_squeeze_permutations,
-                sponge.permutation_count
-            );
             assert_eq!(expected_permutations, sponge.permutation_count);
 
             output

--- a/src/sponge/vanilla.rs
+++ b/src/sponge/vanilla.rs
@@ -481,6 +481,9 @@ impl<F: PrimeField, A: Arity<F>> InnerSpongeAPI<F, A> for Sponge<'_, F, A> {
     fn set_squeeze_pos(&mut self, pos: usize) {
         SpongeTrait::set_squeeze_pos(self, pos);
     }
+    fn add(a: F, b: &F) -> F {
+        a + b
+    }
 
     fn initialize_hasher(&mut self) {
         self.tag_hasher = Default::default();
@@ -659,22 +662,22 @@ mod tests {
             assert_eq!(
                 vec![
                     scalar_from_u64s([
-                        0x46dd799a1809b1cd,
-                        0x60c9aa7c9934e6fe,
-                        0xc1feadcc674de39c,
-                        0x1ee914dbc85bc558
+                        0xba134c4ece935fbc,
+                        0xe73a1d3182eb09eb,
+                        0x2857622b451e20e2,
+                        0x4a04b345e5451f61
                     ]),
                     scalar_from_u64s([
-                        0x52681367b6689438,
-                        0xe4ac15bed72972e5,
-                        0x05ff5305f28bd2d0,
-                        0x56a75f0015c72379
+                        0x20d01828e5f41248,
+                        0x6b2387f9b6218ed6,
+                        0x7733dfe47b8b988d,
+                        0x4150ae19ca65b43f
                     ]),
                     scalar_from_u64s([
-                        0x117bb2fe142e7e71,
-                        0x74aaf50cd3dabf9c,
-                        0x83e8d5b434b6c5c1,
-                        0x28d9ffdeba0fa832
+                        0xd6b7cbcc386afe0d,
+                        0x0ae13bd1b53f84c8,
+                        0x5d58ffaabc54690b,
+                        0x391d3a2807744a01
                     ])
                 ],
                 output


### PR DESCRIPTION
This PR changes the behavior of `SpongeAPI::absorb` to add the absorbed element to the state rather than replace the state element. This makes the `SpongeAPI` match the behavior of the `Sponge` trait and brings this implementation into agreement with the Sponge API Spec (which has been updated to specify this change).

I also added a test which makes explicit the number of permutations which should be expected for a range of absorb/squeeze patterns.

---

UPDATE: I have also added a fix to the circuit. The previous optimization to hard-code the capacity (DST) as constant (saving three constraints) is incorrect for sponges, where the capacity must be derived from the previous permutation.