### PR TITLE
IO pattern

### DIFF
--- a/src/sponge/api.rs
+++ b/src/sponge/api.rs
@@ -142,14 +142,14 @@ impl SpongeOp {
 }
 
 #[derive(Clone)]
-pub enum SpongeParameter {
-    OpSequence(Vec<SpongeOp>),
+pub enum IO {
+    Pattern(Vec<SpongeOp>),
 }
 
-impl SpongeParameter {
+impl IO {
     pub fn value(&self) -> u128 {
         match self {
-            Self::OpSequence(ops) => {
+            Self::Pattern(ops) => {
                 let mut hasher = Hasher::new();
 
                 for op in ops {
@@ -165,7 +165,7 @@ pub trait SpongeAPI<F: PrimeField, A: Arity<F>> {
     type Acc;
     type Value;
 
-    fn start(&mut self, p: SpongeParameter, _: &mut Self::Acc);
+    fn start(&mut self, p: IO, _: &mut Self::Acc);
     fn absorb(&mut self, length: usize, elements: &[Self::Value], acc: &mut Self::Acc);
     fn squeeze(&mut self, length: usize, acc: &mut Self::Acc) -> Vec<Self::Value>;
     fn finish(&mut self, _: &mut Self::Acc) -> Result<(), Error>;
@@ -210,7 +210,7 @@ impl<F: PrimeField, A: Arity<F>, S: InnerSpongeAPI<F, A>> SpongeAPI<F, A> for S 
     type Acc = <S as InnerSpongeAPI<F, A>>::Acc;
     type Value = <S as InnerSpongeAPI<F, A>>::Value;
 
-    fn start(&mut self, p: SpongeParameter, acc: &mut Self::Acc) {
+    fn start(&mut self, p: IO, acc: &mut Self::Acc) {
         let p_value = p.value();
         self.initialize_state(p_value, acc);
 

--- a/src/sponge/api.rs
+++ b/src/sponge/api.rs
@@ -12,6 +12,7 @@ pub enum Error {
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum SpongeOp {
+    DomainSeparator(u32),
     Absorb(u32),
     Squeeze(u32),
 }
@@ -31,6 +32,27 @@ impl IOPattern {
 
     pub fn op_at(&self, i: usize) -> Option<&SpongeOp> {
         self.0.get(i)
+    }
+
+    pub fn ensure_domain_separator(self) -> Self {
+        // Check that IOPattern includes only a single terminal DomainSeparator. If none present, default to 0.
+        let domain_separator = self.0.last().and_then(|l| {
+            if let SpongeOp::DomainSeparator(_) = l {
+                Some(l)
+            } else {
+                None
+            }
+        });
+        let pattern = if domain_separator.is_none() {
+            let mut new_pattern_seq = self.0.clone();
+            new_pattern_seq.push(SpongeOp::DomainSeparator(0));
+            IOPattern(new_pattern_seq)
+        } else {
+            self
+        };
+
+        assert_eq!(1, pattern.0.iter().filter(|op| op.is_separator()).count());
+        pattern
     }
 }
 
@@ -61,25 +83,23 @@ impl Hasher {
         Default::default()
     }
 
-    pub fn new_with_dst(dst: u32) -> Self {
-        let mut h = Self {
-            x: HASHER_BASE,
-            x_i: 1,
-            state: 0,
-            current_op: SpongeOp::Absorb(0),
-        };
-
-        h.update(dst);
-        h
-    }
-
     /// Update hasher's current op to coalesce absorb/squeeze runs.
     pub fn update_op(&mut self, op: SpongeOp) {
         if self.current_op.matches(op) {
             self.current_op = self.current_op.combine(op)
         } else {
             self.finish_op();
+            self.current_op = op;
         }
+    }
+
+    fn finish_op(&mut self) {
+        if !self.current_op.is_separator() && self.current_op.count() == 0 {
+            return;
+        };
+        let op_value = self.current_op.value();
+
+        self.update(op_value);
     }
 
     pub fn update(&mut self, a: u32) {
@@ -88,15 +108,6 @@ impl Hasher {
             .state
             .overflowing_add(self.x_i.overflowing_mul(a as u128).0)
             .0;
-    }
-
-    fn finish_op(&mut self) {
-        if self.current_op.count() == 0 {
-            return;
-        };
-        let op_value = self.current_op.value();
-        self.update(op_value);
-        self.current_op = self.current_op.reset();
     }
 
     pub fn finalize(&mut self) -> u128 {
@@ -110,6 +121,7 @@ impl SpongeOp {
         match self {
             Self::Absorb(_) => Self::Squeeze(0),
             Self::Squeeze(_) => Self::Absorb(0),
+            _ => unimplemented!(),
         }
     }
 
@@ -117,27 +129,29 @@ impl SpongeOp {
         match self {
             Self::Absorb(n) => *n,
             Self::Squeeze(n) => *n,
+            Self::DomainSeparator(n) => *n,
         }
     }
 
     pub fn is_absorb(&self) -> bool {
-        match self {
-            Self::Absorb(_) => true,
-            Self::Squeeze(_) => false,
-        }
+        matches!(self, Self::Absorb(_))
     }
 
     pub fn is_squeeze(&self) -> bool {
-        !self.is_absorb()
+        matches!(self, Self::Squeeze(_))
+    }
+
+    pub fn is_separator(&self) -> bool {
+        matches!(self, Self::DomainSeparator(_))
     }
 
     pub fn combine(&self, other: Self) -> Self {
         assert!(self.matches(other));
-        let other_count = other.count();
 
         match self {
-            Self::Absorb(n) => Self::Absorb(n + other_count),
-            Self::Squeeze(n) => Self::Squeeze(n + other_count),
+            Self::Absorb(n) => Self::Absorb(n + other.count()),
+            Self::Squeeze(n) => Self::Squeeze(n + other.count()),
+            _ => unimplemented!(),
         }
     }
 
@@ -155,6 +169,7 @@ impl SpongeOp {
                 assert_eq!(0, n >> 31);
                 *n
             }
+            Self::DomainSeparator(n) => *n,
         }
     }
 }
@@ -208,8 +223,10 @@ impl<F: PrimeField, A: Arity<F>, S: InnerSpongeAPI<F, A>> SpongeAPI<F, A> for S 
     type Value = <S as InnerSpongeAPI<F, A>>::Value;
 
     fn start(&mut self, p: IOPattern, acc: &mut Self::Acc) {
-        let p_value = p.value();
-        self.set_pattern(p);
+        let defaulted_pattern = p.ensure_domain_separator();
+        let p_value = defaulted_pattern.value();
+
+        self.set_pattern(defaulted_pattern);
         self.initialize_state(p_value, acc);
 
         self.set_absorb_pos(0);
@@ -262,10 +279,66 @@ impl<F: PrimeField, A: Arity<F>, S: InnerSpongeAPI<F, A>> SpongeAPI<F, A> for S 
         self.initialize_state(0, acc);
         let final_io_count = self.increment_io_count();
 
-        if final_io_count == self.pattern().0.len() {
+        if final_io_count == self.pattern().0.len() - 1 {
             Ok(())
         } else {
             Err(Error::ParameterUsageMismatch)
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_tag_values() {
+        let test = |expected_value: u128, pattern: IOPattern| {
+            assert_eq!(expected_value, pattern.value());
+        };
+
+        test(0, IOPattern(vec![]));
+        test(0, IOPattern(vec![SpongeOp::DomainSeparator(0)]));
+        test(
+            340282366920938463463374607431768191899,
+            IOPattern(vec![SpongeOp::DomainSeparator(123)]),
+        );
+        test(
+            340282366920938463463374607090318361668,
+            IOPattern(vec![
+                SpongeOp::Absorb(2),
+                SpongeOp::Squeeze(2),
+                SpongeOp::DomainSeparator(0),
+            ]),
+        );
+        test(
+            340282366920938463463374607090318386949,
+            IOPattern(vec![
+                SpongeOp::Absorb(2),
+                SpongeOp::Squeeze(2),
+                SpongeOp::DomainSeparator(1),
+            ]),
+        );
+        test(
+            340282366920938463463374607090318361668,
+            IOPattern(vec![SpongeOp::Absorb(2), SpongeOp::Squeeze(2)]),
+        );
+        test(
+            340282366920938463463374607090318361668,
+            IOPattern(vec![
+                SpongeOp::Absorb(1),
+                SpongeOp::Absorb(1),
+                SpongeOp::Squeeze(2),
+            ]),
+        );
+        test(
+            340282366920938463463374607090318361668,
+            IOPattern(vec![
+                SpongeOp::Absorb(1),
+                SpongeOp::Absorb(1),
+                SpongeOp::Squeeze(1),
+                SpongeOp::Squeeze(1),
+            ]),
+        );
     }
 }

--- a/src/sponge/circuit.rs
+++ b/src/sponge/circuit.rs
@@ -435,7 +435,7 @@ mod tests {
             let mut ns = cs.namespace(|| "ns");
             let acc = &mut ns;
 
-            sponge.start(parameter.clone(), acc);
+            sponge.start(parameter.clone(), None, acc);
             SpongeAPI::absorb(
                 &mut sponge,
                 1,
@@ -467,7 +467,7 @@ mod tests {
             let mut sponge = Sponge::new_with_constants(&p, Mode::Simplex);
             let acc = &mut ();
 
-            sponge.start(parameter, acc);
+            sponge.start(parameter, None, acc);
             SpongeAPI::absorb(&mut sponge, 1, &[Fr::from(123)], acc);
             SpongeAPI::absorb(
                 &mut sponge,
@@ -513,7 +513,7 @@ mod tests {
             let mut ns = cs.namespace(|| "ns");
             let acc = &mut ns;
 
-            sponge.start(parameter, acc);
+            sponge.start(parameter, None, acc);
             SpongeAPI::absorb(
                 &mut sponge,
                 1,
@@ -573,7 +573,7 @@ mod tests {
                     .take(absorb_count)
                     .collect();
 
-            sponge.start(parameter.clone(), acc);
+            sponge.start(parameter.clone(), None, acc);
 
             SpongeAPI::absorb(&mut sponge, absorb_count as u32, &elts[..], acc);
 
@@ -595,7 +595,7 @@ mod tests {
                 .take(absorb_count)
                 .collect();
 
-            sponge.start(parameter, acc);
+            sponge.start(parameter, None, acc);
             SpongeAPI::absorb(&mut sponge, absorb_count as u32, &elts[..], acc);
 
             let output = SpongeAPI::squeeze(&mut sponge, squeeze_count as u32, acc);
@@ -632,7 +632,7 @@ mod tests {
 
             let parameter = IOPattern(vec![SpongeOp::Absorb(5), SpongeOp::Squeeze(1)]);
 
-            sponge.start(parameter, acc);
+            sponge.start(parameter, None, acc);
 
             SpongeAPI::absorb(
                 &mut sponge,

--- a/src/sponge/circuit.rs
+++ b/src/sponge/circuit.rs
@@ -4,7 +4,7 @@ use crate::matrix::Matrix;
 use crate::mds::SparseMatrix;
 use crate::poseidon::{Arity, Poseidon, PoseidonConstants};
 use crate::sponge::{
-    api::{Hasher, InnerSpongeAPI, SpongeOp, SpongeParameter},
+    api::{Hasher, InnerSpongeAPI, SpongeOp, IO},
     vanilla::{Direction, Mode, SpongeTrait},
 };
 use crate::Strength;
@@ -30,7 +30,7 @@ where
     permutation_count: usize,
     state: PoseidonCircuit2<'a, F, A>,
     queue: VecDeque<Elt<F>>,
-    parameter: SpongeParameter,
+    parameter: IO,
     tag: u128,
     tag_hasher: Hasher,
     _c: PhantomData<C>,
@@ -54,7 +54,7 @@ impl<'a, F: PrimeField, A: Arity<F>, CS: 'a + ConstraintSystem<F>> SpongeTrait<'
             permutation_count: 0,
             state: PoseidonCircuit2::new_empty::<CS>(constants),
             queue: VecDeque::with_capacity(A::to_usize()),
-            parameter: SpongeParameter::OpSequence(Vec::new()),
+            parameter: IO::Pattern(Vec::new()),
             tag: 0,
             tag_hasher: Default::default(),
             _c: Default::default(),
@@ -425,7 +425,7 @@ mod tests {
     fn test_sponge_api_circuit_simple() {
         use crate::sponge::api::SpongeAPI;
 
-        let parameter = SpongeParameter::OpSequence(vec![
+        let parameter = IO::Pattern(vec![
             SpongeOp::Absorb(1),
             SpongeOp::Absorb(5),
             SpongeOp::Squeeze(3),
@@ -502,7 +502,7 @@ mod tests {
     fn test_sponge_api_circuit_failure() {
         use crate::sponge::api::SpongeAPI;
 
-        let parameter = SpongeParameter::OpSequence(vec![
+        let parameter = IO::Pattern(vec![
             SpongeOp::Absorb(1),
             SpongeOp::Absorb(5),
             SpongeOp::Squeeze(3),
@@ -560,7 +560,7 @@ mod tests {
         let expected_squeeze_permutations = (squeeze_count - 1) / arity;
         let expected_permutations = expected_absorb_permutations + expected_squeeze_permutations;
 
-        let parameter = SpongeParameter::OpSequence(vec![
+        let parameter = IO::Pattern(vec![
             SpongeOp::Absorb(absorb_count as u32),
             SpongeOp::Squeeze(squeeze_count as u32),
         ]);
@@ -634,8 +634,7 @@ mod tests {
 
             let acc = &mut ns;
 
-            let parameter =
-                SpongeParameter::OpSequence(vec![SpongeOp::Absorb(5), SpongeOp::Squeeze(1)]);
+            let parameter = IO::Pattern(vec![SpongeOp::Absorb(5), SpongeOp::Squeeze(1)]);
 
             sponge.start(parameter, acc);
 

--- a/src/sponge/circuit.rs
+++ b/src/sponge/circuit.rs
@@ -31,8 +31,6 @@ where
     state: PoseidonCircuit2<'a, F, A>,
     queue: VecDeque<Elt<F>>,
     pattern: IOPattern,
-    tag: u128,
-    tag_hasher: Hasher,
     io_count: usize,
     _c: PhantomData<C>,
 }
@@ -56,8 +54,6 @@ impl<'a, F: PrimeField, A: Arity<F>, CS: 'a + ConstraintSystem<F>> SpongeTrait<'
             state: PoseidonCircuit2::new_empty::<CS>(constants),
             queue: VecDeque::with_capacity(A::to_usize()),
             pattern: IOPattern(Vec::new()),
-            tag: 0,
-            tag_hasher: Default::default(),
             io_count: 0,
             _c: Default::default(),
         }
@@ -177,7 +173,6 @@ impl<'a, F: PrimeField, A: Arity<F>, CS: 'a + ConstraintSystem<F>> InnerSpongeAP
     type Value = Elt<F>;
 
     fn initialize_capacity(&mut self, tag: u128, _acc: &mut Self::Acc) {
-        self.tag = tag;
         let mut repr = F::Repr::default();
         repr.as_mut()[..16].copy_from_slice(&tag.to_le_bytes());
 
@@ -219,20 +214,6 @@ impl<'a, F: PrimeField, A: Arity<F>, CS: 'a + ConstraintSystem<F>> InnerSpongeAP
     }
     fn add(a: Elt<F>, b: &Elt<F>) -> Elt<F> {
         a.add_ref(b).unwrap()
-    }
-
-    fn initialize_hasher(&mut self) {
-        self.tag_hasher = Default::default();
-    }
-    fn update_hasher(&mut self, op: SpongeOp) {
-        self.tag_hasher.update_op(op);
-    }
-    fn finalize_hasher(&mut self) -> u128 {
-        self.tag_hasher.finalize()
-    }
-
-    fn get_tag(&self) -> u128 {
-        self.tag
     }
 
     fn pattern(&self) -> &IOPattern {

--- a/src/sponge/vanilla.rs
+++ b/src/sponge/vanilla.rs
@@ -57,8 +57,6 @@ pub struct Sponge<'a, F: PrimeField, A: Arity<F>> {
     squeeze_pos: usize,
     queue: VecDeque<F>,
     pattern: IOPattern,
-    tag: u128,
-    tag_hasher: Hasher,
     io_count: usize,
 }
 
@@ -318,8 +316,6 @@ impl<'a, F: PrimeField, A: Arity<F>> SpongeTrait<'a, F, A> for Sponge<'a, F, A> 
             squeeze_pos: 0,
             queue: VecDeque::with_capacity(A::to_usize()),
             pattern: IOPattern(Vec::new()),
-            tag: 0,
-            tag_hasher: Default::default(),
             io_count: 0,
         }
     }
@@ -444,7 +440,6 @@ impl<F: PrimeField, A: Arity<F>> InnerSpongeAPI<F, A> for Sponge<'_, F, A> {
     type Value = F;
 
     fn initialize_capacity(&mut self, tag: u128, _: &mut ()) {
-        self.tag = tag;
         let mut repr = F::Repr::default();
         repr.as_mut()[..16].copy_from_slice(&tag.to_le_bytes());
 
@@ -485,20 +480,6 @@ impl<F: PrimeField, A: Arity<F>> InnerSpongeAPI<F, A> for Sponge<'_, F, A> {
     }
     fn add(a: F, b: &F) -> F {
         a + b
-    }
-
-    fn initialize_hasher(&mut self) {
-        self.tag_hasher = Default::default();
-    }
-    fn update_hasher(&mut self, op: SpongeOp) {
-        self.tag_hasher.update_op(op);
-    }
-    fn finalize_hasher(&mut self) -> u128 {
-        self.tag_hasher.finalize()
-    }
-
-    fn get_tag(&self) -> u128 {
-        self.tag
     }
 
     fn pattern(&self) -> &IOPattern {

--- a/src/sponge/vanilla.rs
+++ b/src/sponge/vanilla.rs
@@ -1,6 +1,6 @@
 use crate::hash_type::HashType;
 use crate::poseidon::{Arity, Poseidon, PoseidonConstants};
-use crate::sponge::api::{Hasher, InnerSpongeAPI, SpongeOp, SpongeParameter};
+use crate::sponge::api::{Hasher, InnerSpongeAPI, SpongeOp, IO};
 use crate::{Error, Strength};
 use ff::PrimeField;
 use std::collections::VecDeque;
@@ -56,7 +56,7 @@ pub struct Sponge<'a, F: PrimeField, A: Arity<F>> {
     direction: Direction,
     squeeze_pos: usize,
     queue: VecDeque<F>,
-    parameter: SpongeParameter,
+    parameter: IO,
     tag: u128,
     tag_hasher: Hasher,
 }
@@ -316,7 +316,7 @@ impl<'a, F: PrimeField, A: Arity<F>> SpongeTrait<'a, F, A> for Sponge<'a, F, A> 
             squeezed: 0,
             squeeze_pos: 0,
             queue: VecDeque::with_capacity(A::to_usize()),
-            parameter: SpongeParameter::OpSequence(Vec::new()),
+            parameter: IO::Pattern(Vec::new()),
             tag: 0,
             tag_hasher: Default::default(),
         }
@@ -630,7 +630,7 @@ mod tests {
     fn test_sponge_api_simple() {
         use crate::sponge::api::SpongeAPI;
 
-        let parameter = SpongeParameter::OpSequence(vec![
+        let parameter = IO::Pattern(vec![
             SpongeOp::Absorb(1),
             SpongeOp::Absorb(5),
             SpongeOp::Squeeze(3),
@@ -689,7 +689,7 @@ mod tests {
     fn test_sponge_api_failure() {
         use crate::sponge::api::SpongeAPI;
 
-        let parameter = SpongeParameter::OpSequence(vec![
+        let parameter = IO::Pattern(vec![
             SpongeOp::Absorb(1),
             SpongeOp::Absorb(5),
             SpongeOp::Squeeze(3),

--- a/src/sponge/vanilla.rs
+++ b/src/sponge/vanilla.rs
@@ -659,22 +659,22 @@ mod tests {
             assert_eq!(
                 vec![
                     scalar_from_u64s([
-                        0xba134c4ece935fbc,
-                        0xe73a1d3182eb09eb,
-                        0x2857622b451e20e2,
-                        0x4a04b345e5451f61
+                        0xd891815983f3ea1e,
+                        0xa1f7c82951d37ba6,
+                        0xfe4d3c5fa63ed71c,
+                        0x0ca887769c6aa1ae
                     ]),
                     scalar_from_u64s([
-                        0x20d01828e5f41248,
-                        0x6b2387f9b6218ed6,
-                        0x7733dfe47b8b988d,
-                        0x4150ae19ca65b43f
+                        0xc7909f76adede2c9,
+                        0x635c7b88ed65384e,
+                        0x87de07b469968b55,
+                        0x44d46d6e6c5955a1
                     ]),
                     scalar_from_u64s([
-                        0xd6b7cbcc386afe0d,
-                        0x0ae13bd1b53f84c8,
-                        0x5d58ffaabc54690b,
-                        0x391d3a2807744a01
+                        0x17867c2f5d82207b,
+                        0xa809e7e861a2580c,
+                        0xb022568089e9d532,
+                        0x65536a37b5eef0f2
                     ])
                 ],
                 output

--- a/src/sponge/vanilla.rs
+++ b/src/sponge/vanilla.rs
@@ -638,7 +638,7 @@ mod tests {
             let mut sponge = Sponge::new_with_constants(&p, Mode::Simplex);
             let acc = &mut ();
 
-            sponge.start(parameter, acc);
+            sponge.start(parameter, None, acc);
             SpongeAPI::absorb(&mut sponge, 1, &[Fr::from(123)], acc);
             SpongeAPI::absorb(
                 &mut sponge,
@@ -698,7 +698,7 @@ mod tests {
             let mut sponge = Sponge::new_with_constants(&p, Mode::Simplex);
             let acc = &mut ();
 
-            sponge.start(parameter, acc);
+            sponge.start(parameter, None, acc);
             SpongeAPI::absorb(&mut sponge, 1, &[Fr::from(123)], acc);
             SpongeAPI::absorb(
                 &mut sponge,


### PR DESCRIPTION
This PR renames `SpongeParameter::OpSequence` to `IOPattern` and enforces the specific pattern committed to at runtime. However, alternate equivalent patterns (after coalescing runs of absorb/squeeze ops) are still have the same tag so are compatible. This allows alternate implementations to enjoy runtime safety (checked against declared pattern) while still allowing freedom to chunk operations as desired. These changes bring the Sponge API implementation in sync with the spec (https://hackmd.io/bHgsH6mMStCVibM_wYvb2w) in its current state.