### PR TITLE
Update CHANGELOG for 7.1.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://book.async.rs/overview
 
 ## Unreleased
 
+## 7.1.0 - 2022-8-8
+
+- Add Sponge API to README. (https://github.com/filecoin-project/neptune/pull/158)
+- IO pattern (https://github.com/filecoin-project/neptune/pull/157)
+- Sponge absorb add (https://github.com/filecoin-project/neptune/pull/156)
+- Add sponge circuit synthesis test and remove make_elt method. (https://github.com/filecoin-project/neptune/pull/154)
+
 ## 7.0.0 - 2022-7-21
 - Implement sponge construction. (https://github.com/filecoin-project/neptune/pull/151)
 - feat: support other fields (https://github.com/filecoin-project/neptune/pull/135)


### PR DESCRIPTION
We will release these changes as 7.1.0. They include a bug-fix for the initial Sponge API implementation, and some small API changes to keep the neptune reference implementation in sync with the spec itself as that has been finalized.

The minor release is so Filecoin (which does not use the Sponge API) won't automatically pick up the release, even though it should be unaffected. Nova does use the Sponge API but needs this release (the bug fix in particular) before it can rely on the library.
