### PR TITLE
Rename write_rate_element to add_rate_element.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://book.async.rs/overview
 
 ## Unreleased
 
+## 7.2.0 - 2022-8-9
+- Change write_rate_element to add_rate_element to agree with spec.
+
 ## 7.1.0 - 2022-8-8
 
 - Add Sponge API to README. (https://github.com/filecoin-project/neptune/pull/158)

--- a/src/sponge/api.rs
+++ b/src/sponge/api.rs
@@ -162,7 +162,7 @@ pub trait InnerSpongeAPI<F: PrimeField, A: Arity<F>> {
 
     fn initialize_capacity(&mut self, tag: u128, acc: &mut Self::Acc);
     fn read_rate_element(&mut self, offset: usize) -> Self::Value;
-    fn write_rate_element(&mut self, offset: usize, x: &Self::Value);
+    fn add_rate_element(&mut self, offset: usize, x: &Self::Value);
     fn permute(&mut self, acc: &mut Self::Acc);
 
     // Supplemental methods needed for a generic implementation.
@@ -178,7 +178,7 @@ pub trait InnerSpongeAPI<F: PrimeField, A: Arity<F>> {
         self.initialize_capacity(p_value, acc);
 
         for i in 0..self.rate() {
-            self.write_rate_element(i, &Self::zero());
+            self.add_rate_element(i, &Self::zero());
         }
     }
 
@@ -214,7 +214,7 @@ impl<F: PrimeField, A: Arity<F>, S: InnerSpongeAPI<F, A>> SpongeAPI<F, A> for S 
                 self.set_absorb_pos(0);
             }
             let old = self.read_rate_element(self.absorb_pos());
-            self.write_rate_element(self.absorb_pos(), &S::add(old, element));
+            self.add_rate_element(self.absorb_pos(), &S::add(old, element));
             self.set_absorb_pos(self.absorb_pos() + 1);
         }
         let op = SpongeOp::Absorb(length);

--- a/src/sponge/circuit.rs
+++ b/src/sponge/circuit.rs
@@ -184,7 +184,7 @@ impl<'a, F: PrimeField, A: Arity<F>, CS: 'a + ConstraintSystem<F>> InnerSpongeAP
     fn read_rate_element(&mut self, offset: usize) -> Self::Value {
         self.element(offset + SpongeTrait::capacity(self))
     }
-    fn write_rate_element(&mut self, offset: usize, x: &Self::Value) {
+    fn add_rate_element(&mut self, offset: usize, x: &Self::Value) {
         self.set_element(offset + SpongeTrait::capacity(self), x.clone());
     }
     fn permute(&mut self, acc: &mut Self::Acc) {

--- a/src/sponge/vanilla.rs
+++ b/src/sponge/vanilla.rs
@@ -450,7 +450,7 @@ impl<F: PrimeField, A: Arity<F>> InnerSpongeAPI<F, A> for Sponge<'_, F, A> {
     fn read_rate_element(&mut self, offset: usize) -> F {
         self.element(offset + SpongeTrait::capacity(self))
     }
-    fn write_rate_element(&mut self, offset: usize, x: &F) {
+    fn add_rate_element(&mut self, offset: usize, x: &F) {
         self.set_element(offset + SpongeTrait::capacity(self), *x);
     }
     fn permute(&mut self, acc: &mut ()) {


### PR DESCRIPTION
This PR implements a quick fix to rename `InnerSpongeAPI::write_rate_element` to `add_rate_element` — making the implementation conform to the current spec. Hopefully this will be the last such minor fixup.