### PR TITLE
chore: fix CI MacOS build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
 
   test_darwin_default_and_opencl:
     macos:
-      xcode: "12.5.0"
+      xcode: "13.4.1"
     working_directory: ~/crate
     resource_class: large
     steps:


### PR DESCRIPTION
CircleCI stopped working with Xcode 12.5.1, hence upgrade
to the latest non-beta version 13.4.1.