### PR TITLE
Implement serde for PoseidonConstants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ ff = "0.12.0"
 generic-array = "0.14.4"
 itertools = { version = "0.8.0" }
 log = "0.4.8"
-pasta_curves = { version = "0.5.0", features = ["serde"], package = "fil_pasta_curves" }
+pasta_curves = { version = "0.5.1", features = ["serde"], package = "fil_pasta_curves" }
 trait-set = "0.3.0"
 serde = { version = "1.0", features = ["derive"] }
 
@@ -36,7 +36,7 @@ sha2 = "0.9"
 blstrs = "0.6.1"
 ec-gpu = { version = "0.2.0", optional = true }
 ec-gpu-gen = { version = "0.5.0", optional = true }
-pasta_curves = { version = "0.5.0", package = "fil_pasta_curves" }
+pasta_curves = { version = "0.5.1", package = "fil_pasta_curves" }
 
 [[bench]]
 name = "hash"
@@ -73,5 +73,5 @@ members = [
   "gbench",
 ]
 
-[patch.crates-io]
-fil_pasta_curves = { git = "https://github.com/filecoin-project/fil_pasta_curves" }
+#[patch.crates-io]
+#fil_pasta_curves = { git = "https://github.com/filecoin-project/fil_pasta_curves" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,9 @@ ff = "0.12.0"
 generic-array = "0.14.4"
 itertools = { version = "0.8.0" }
 log = "0.4.8"
-pasta_curves = { version = "0.5.1", package = "fil_pasta_curves" }
+pasta_curves = { version = "0.5.0", features = ["serde"], package = "fil_pasta_curves" }
 trait-set = "0.3.0"
+serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 blstrs = "0.6.1"
@@ -35,7 +36,7 @@ sha2 = "0.9"
 blstrs = "0.6.1"
 ec-gpu = { version = "0.2.0", optional = true }
 ec-gpu-gen = { version = "0.5.0", optional = true }
-pasta_curves = { version = "0.5.1", package = "fil_pasta_curves" }
+pasta_curves = { version = "0.5.0", package = "fil_pasta_curves" }
 
 [[bench]]
 name = "hash"
@@ -73,6 +74,4 @@ members = [
 ]
 
 [patch.crates-io]
-bellperson = { path = "../bellperson" }
-ec-gpu-gen = { git = "https://github.com/filecoin-project/ec-gpu" }
-pasta_curves = { path = "../pasta_curves" }
+fil_pasta_curves = { git = "https://github.com/filecoin-project/fil_pasta_curves" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,3 +71,8 @@ pasta = ["pasta_curves/gpu"]
 members = [
   "gbench",
 ]
+
+[patch.crates-io]
+bellperson = { path = "../bellperson" }
+ec-gpu-gen = { git = "https://github.com/filecoin-project/ec-gpu" }
+pasta_curves = { path = "../pasta_curves" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,3 @@ pasta = ["pasta_curves/gpu"]
 members = [
   "gbench",
 ]
-
-#[patch.crates-io]
-#fil_pasta_curves = { git = "https://github.com/filecoin-project/fil_pasta_curves" }

--- a/gbench/Cargo.toml
+++ b/gbench/Cargo.toml
@@ -18,7 +18,7 @@ log = "0.4.8"
 neptune = { path = "../", default-features = false, features = ["arity8", "arity11", "bls", "pasta"] }
 structopt = { version = "0.3", default-features = false }
 blstrs = { version = "0.6.1", features = ["gpu"] }
-pasta_curves = { version = "0.5.1", features = ["gpu"], package = "fil_pasta_curves" }
+pasta_curves = { version = "0.5.0", features = ["gpu"], package = "fil_pasta_curves" }
 ec-gpu = "0.2.0"
 ec-gpu-gen = "0.5.0"
 

--- a/gbench/Cargo.toml
+++ b/gbench/Cargo.toml
@@ -18,7 +18,7 @@ log = "0.4.8"
 neptune = { path = "../", default-features = false, features = ["arity8", "arity11", "bls", "pasta"] }
 structopt = { version = "0.3", default-features = false }
 blstrs = { version = "0.6.1", features = ["gpu"] }
-pasta_curves = { version = "0.5.0", features = ["gpu"], package = "fil_pasta_curves" }
+pasta_curves = { version = "0.5.1", features = ["gpu"], package = "fil_pasta_curves" }
 ec-gpu = "0.2.0"
 ec-gpu-gen = "0.5.0"
 

--- a/src/hash_type.rs
+++ b/src/hash_type.rs
@@ -12,14 +12,16 @@
 /// may still express the full range of hash function types.
 use crate::{Arity, Strength};
 use ff::PrimeField;
+use serde::{Serialize, Deserialize};
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum HashType<F: PrimeField, A: Arity<F>> {
     MerkleTree,
     MerkleTreeSparse(u64),
     VariableLength,
     ConstantLength(usize),
     Encryption,
+    #[serde(skip)]
     Custom(CType<F, A>),
     Sponge,
 }
@@ -64,7 +66,7 @@ impl<F: PrimeField, A: Arity<F>> HashType<F, A> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum CType<F: PrimeField, A: Arity<F>> {
     Arbitrary(u64),
     _Phantom((F, A)),

--- a/src/hash_type.rs
+++ b/src/hash_type.rs
@@ -12,7 +12,7 @@
 /// may still express the full range of hash function types.
 use crate::{Arity, Strength};
 use ff::PrimeField;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum HashType<F: PrimeField, A: Arity<F>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,9 +11,9 @@ use blstrs::Scalar as Fr;
 pub use error::Error;
 use ff::PrimeField;
 use generic_array::GenericArray;
+use serde::{Deserialize, Serialize};
 use std::fmt;
 use trait_set::trait_set;
-use serde::{Serialize, Deserialize};
 
 #[cfg(all(
     any(feature = "cuda", feature = "opencl"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ use ff::PrimeField;
 use generic_array::GenericArray;
 use std::fmt;
 use trait_set::trait_set;
+use serde::{Serialize, Deserialize};
 
 #[cfg(all(
     any(feature = "cuda", feature = "opencl"),
@@ -92,11 +93,13 @@ trait_set! {
    pub trait NeptuneField = PrimeField + ec_gpu::GpuName;
 }
 
+mod serde_impl;
+
 pub(crate) const TEST_SEED: [u8; 16] = [
     0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc, 0xe5,
 ];
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum Strength {
     Standard,
     Strengthened,

--- a/src/mds.rs
+++ b/src/mds.rs
@@ -2,13 +2,14 @@
 #![allow(clippy::ptr_arg)]
 
 use ff::PrimeField;
+use serde::{Serialize, Deserialize};
 
 use crate::matrix;
 use crate::matrix::{
     apply_matrix, invert, is_identity, is_invertible, is_square, mat_mul, minor, transpose, Matrix,
 };
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MdsMatrices<F: PrimeField> {
     pub m: Matrix<F>,
     pub m_inv: Matrix<F>,
@@ -44,7 +45,7 @@ pub fn derive_mds_matrices<F: PrimeField>(m: Matrix<F>) -> MdsMatrices<F> {
 /// This means its first row and column are each dense, and the interior matrix
 /// (minor to the element in both the row and column) is the identity.
 /// We will pluralize this compact structure `sparse_matrixes` to distinguish from `sparse_matrices` from which they are created.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SparseMatrix<F: PrimeField> {
     /// `w_hat` is the first column of the M'' matrix. It will be directly multiplied (scalar product) with a row of state elements.
     pub w_hat: Vec<F>,

--- a/src/mds.rs
+++ b/src/mds.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::ptr_arg)]
 
 use ff::PrimeField;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 use crate::matrix;
 use crate::matrix::{

--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -106,7 +106,7 @@ where
     A: Arity<F>,
 {
     pub mds_matrices: MdsMatrices<F>,
-    pub round_constants: Vec<F>,
+    pub round_constants: Option<Vec<F>>,
     pub compressed_round_constants: Vec<F>,
     pub pre_sparse_matrix: Matrix<F>,
     pub sparse_matrixes: Vec<SparseMatrix<F>>,
@@ -207,7 +207,7 @@ where
 
         Self {
             mds_matrices,
-            round_constants,
+            round_constants: Some(round_constants),
             compressed_round_constants,
             pre_sparse_matrix,
             sparse_matrixes,

--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -10,6 +10,7 @@ use generic_array::{sequence::GenericSequence, typenum, ArrayLength, GenericArra
 use std::marker::PhantomData;
 use typenum::marker_traits::Unsigned;
 use typenum::*;
+use serde::{Serialize, Deserialize};
 
 /// Available arities for the Poseidon hasher.
 pub trait Arity<T>: ArrayLength<T> {
@@ -117,7 +118,8 @@ where
     pub half_full_rounds: usize,
     pub partial_rounds: usize,
     pub hash_type: HashType<F, A>,
-    _a: PhantomData<A>,
+    //NOTE: temporalily public
+    pub _a: PhantomData<A>,
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -7,10 +7,10 @@ use crate::{matrix, quintic_s_box, BatchHasher, Strength, DEFAULT_STRENGTH};
 use crate::{round_constants, round_numbers, Error};
 use ff::PrimeField;
 use generic_array::{sequence::GenericSequence, typenum, ArrayLength, GenericArray};
+use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 use typenum::marker_traits::Unsigned;
 use typenum::*;
-use serde::{Serialize, Deserialize};
 
 /// Available arities for the Poseidon hasher.
 pub trait Arity<T>: ArrayLength<T> {
@@ -118,7 +118,7 @@ where
     pub half_full_rounds: usize,
     pub partial_rounds: usize,
     pub hash_type: HashType<F, A>,
-    //NOTE: temporalily public
+    //NOTE: temporarily public
     pub _a: PhantomData<A>,
 }
 

--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -118,8 +118,7 @@ where
     pub half_full_rounds: usize,
     pub partial_rounds: usize,
     pub hash_type: HashType<F, A>,
-    //NOTE: temporarily public
-    pub _a: PhantomData<A>,
+    pub(crate) _a: PhantomData<A>,
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/poseidon_alt.rs
+++ b/src/poseidon_alt.rs
@@ -49,6 +49,8 @@ where
     let pre_round_keys = p
         .constants
         .round_constants
+        .as_ref()
+        .unwrap()
         .iter()
         .skip(p.constants_offset)
         .map(Some);
@@ -132,6 +134,8 @@ pub fn full_round_dynamic<F, A>(
     let pre_round_keys = p
         .constants
         .round_constants
+        .as_ref()
+        .unwrap()
         .iter()
         .skip(p.constants_offset)
         .map(|x| {
@@ -148,6 +152,8 @@ pub fn full_round_dynamic<F, A>(
         let post_vec = p
             .constants
             .round_constants
+            .as_ref()
+            .unwrap()
             .iter()
             .skip(
                 p.constants_offset
@@ -227,11 +233,14 @@ where
     F: PrimeField,
     A: Arity<F>,
 {
-    for (element, round_constant) in p
-        .elements
-        .iter_mut()
-        .zip(p.constants.round_constants.iter().skip(p.constants_offset))
-    {
+    for (element, round_constant) in p.elements.iter_mut().zip(
+        p.constants
+            .round_constants
+            .as_ref()
+            .unwrap()
+            .iter()
+            .skip(p.constants_offset),
+    ) {
         element.add_assign(round_constant);
     }
 

--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -1,270 +1,276 @@
-use std::fmt;
-use serde::{
-  ser::{Serializer, SerializeStruct},
-  Serialize,
-  Deserialize,
-  de::{self, Deserializer, Visitor, SeqAccess, MapAccess},
-};
-use generic_array::typenum;
-use typenum::Unsigned;
 use ff::PrimeField;
-use std::marker::PhantomData;
+use generic_array::typenum;
 use pasta_curves::pallas::Scalar as S1;
+use serde::{
+    de::{self, Deserializer, MapAccess, SeqAccess, Visitor},
+    ser::{SerializeStruct, Serializer},
+    Deserialize, Serialize,
+};
+use std::fmt;
+use std::marker::PhantomData;
+use typenum::Unsigned;
 
-use crate::Arity;
+use crate::hash_type::HashType;
 use crate::poseidon::PoseidonConstants;
+use crate::Arity;
 
 impl<F, A> Serialize for PoseidonConstants<F, A>
-  where
-  F: PrimeField + Serialize,
-  A: Arity<F>,
+where
+    F: PrimeField + Serialize,
+    A: Arity<F>,
 {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    let mut state = serializer.serialize_struct("PoseidonConstants", 11)?;
-    state.serialize_field("mdsmatrices", &self.mds_matrices)?;
-    state.serialize_field("roundconstants", &self.round_constants)?;
-    state.serialize_field("compressedroundconstants", &self.compressed_round_constants)?;
-    state.serialize_field("presparsematrix", &self.pre_sparse_matrix)?;
-    state.serialize_field("sparsematrixes", &self.sparse_matrixes)?;
-    state.serialize_field("strength", &self.strength)?;
-    state.serialize_field("domaintag", &self.domain_tag)?;
-    state.serialize_field("fullrounds", &self.full_rounds)?;
-    state.serialize_field("halffullrounds", &self.half_full_rounds)?;
-    state.serialize_field("partialrounds", &self.partial_rounds)?;
-    state.serialize_field("hashtype", &self.hash_type)?;
-    state.end()
-  }
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("PoseidonConstants", 9)?;
+        state.serialize_field("mds", &self.mds_matrices)?;
+        state.serialize_field("rc", &self.round_constants)?;
+        state.serialize_field("crc", &self.compressed_round_constants)?;
+        state.serialize_field("psm", &self.pre_sparse_matrix)?;
+        state.serialize_field("sm", &self.sparse_matrixes)?;
+        state.serialize_field("s", &self.strength)?;
+        state.serialize_field("fr", &self.full_rounds)?;
+        state.serialize_field("pr", &self.partial_rounds)?;
+        state.serialize_field("ht", &self.hash_type)?;
+        state.end()
+    }
 }
 
 impl<'de, F, A> Deserialize<'de> for PoseidonConstants<F, A>
 where
-  F: PrimeField + Deserialize<'de>,
-  A: Arity<F>,
+    F: PrimeField + Deserialize<'de>,
+    A: Arity<F>,
 {
-  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-  where D: Deserializer<'de>,
-  {
-    #[derive(Deserialize)]
-    #[serde(field_identifier, rename_all = "lowercase")]
-    enum Field {
-      MdsMatrices,
-      RoundConstants,
-      CompressedRoundConstants,
-      PreSparseMatrix,
-      SparseMatrixes,
-      Strength,
-      DomainTag,
-      FullRounds,
-      HalfFullRounds,
-      PartialRounds,
-      HashType,
-    }
-
-    struct PoseidonConstantsVisitor<F, A>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-      F: PrimeField,
-      A: Arity<F>,
+        D: Deserializer<'de>,
     {
-      _f: PhantomData<F>,
-      _a: PhantomData<A>,
-    }
-
-    impl<'de, F, A> Visitor<'de> for PoseidonConstantsVisitor<F, A>
-    where
-      F: PrimeField + Deserialize<'de>,
-      A: Arity<F>,
-    {
-      type Value = PoseidonConstants<F, A>;
-
-      fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("struct PoseidonConstants")
-      }
-
-      fn visit_seq<V>(self, mut seq: V) -> Result<PoseidonConstants<F, A>, V::Error>
-      where
-        V: SeqAccess<'de>,
-      {
-        let mds_matrices = seq.next_element()?
-          .ok_or_else(|| de::Error::invalid_length(0, &self))?;
-        let round_constants = seq.next_element()?
-          .ok_or_else(|| de::Error::invalid_length(1, &self))?;
-        let compressed_round_constants = seq.next_element()?
-          .ok_or_else(|| de::Error::invalid_length(2, &self))?;
-        let pre_sparse_matrix = seq.next_element()?
-          .ok_or_else(|| de::Error::invalid_length(3, &self))?;
-        let sparse_matrixes = seq.next_element()?
-          .ok_or_else(|| de::Error::invalid_length(3, &self))?;
-        let strength = seq.next_element()?
-          .ok_or_else(|| de::Error::invalid_length(4, &self))?;
-        let domain_tag = seq.next_element()?
-          .ok_or_else(|| de::Error::invalid_length(5, &self))?;
-        let full_rounds = seq.next_element()?
-          .ok_or_else(|| de::Error::invalid_length(6, &self))?;
-        let half_full_rounds = seq.next_element()?
-          .ok_or_else(|| de::Error::invalid_length(7, &self))?;
-        let partial_rounds = seq.next_element()?
-          .ok_or_else(|| de::Error::invalid_length(8, &self))?;
-        let hash_type = seq.next_element()?
-          .ok_or_else(|| de::Error::invalid_length(9, &self))?;
-        Ok(PoseidonConstants {
-	  mds_matrices,
-	  round_constants,
-	  compressed_round_constants,
-	  pre_sparse_matrix,
-	  sparse_matrixes,
-	  strength,
-	  domain_tag,
-	  full_rounds,
-	  half_full_rounds,
-	  partial_rounds,
-	  hash_type,
-	  _a: PhantomData
-	})
-      }
-
-      fn visit_map<V>(self, mut map: V) -> Result<PoseidonConstants<F, A>, V::Error>
-      where
-        V: MapAccess<'de>,
-      {
-	let mut mds_matrices = None;
-	let mut round_constants = None;
-	let mut compressed_round_constants = None;
-	let mut pre_sparse_matrix = None;
-	let mut sparse_matrixes = None;
-	let mut strength = None;
-	let mut domain_tag = None;
-	let mut full_rounds = None;
-	let mut half_full_rounds = None;
-	let mut partial_rounds = None;
-	let mut hash_type = None;
-        while let Some(key) = map.next_key()? {
-          match key {
-            Field::MdsMatrices => {
-              if mds_matrices.is_some() {
-                return Err(de::Error::duplicate_field("mds_matrices"));
-              }
-              mds_matrices = Some(map.next_value()?);
-            }
-            Field::RoundConstants => {
-              if round_constants.is_some() {
-                return Err(de::Error::duplicate_field("round_constants"));
-              }
-              round_constants = Some(map.next_value()?);
-            }
-            Field::CompressedRoundConstants => {
-              if compressed_round_constants.is_some() {
-                return Err(de::Error::duplicate_field("compressed_round_constants"));
-              }
-              compressed_round_constants = Some(map.next_value()?);
-            }
-            Field::PreSparseMatrix => {
-              if pre_sparse_matrix.is_some() {
-                return Err(de::Error::duplicate_field("pre_sparse_matrix"));
-              }
-              pre_sparse_matrix = Some(map.next_value()?);
-            }
-            Field::SparseMatrixes => {
-              if sparse_matrixes.is_some() {
-                return Err(de::Error::duplicate_field("sparse_matrixes"));
-              }
-              sparse_matrixes = Some(map.next_value()?);
-            }
-            Field::Strength => {
-              if strength.is_some() {
-                return Err(de::Error::duplicate_field("strength"));
-              }
-              strength = Some(map.next_value()?);
-            }
-            Field::DomainTag => {
-              if domain_tag.is_some() {
-                return Err(de::Error::duplicate_field("domain_tag"));
-              }
-              domain_tag = Some(map.next_value()?);
-            }
-            Field::FullRounds => {
-              if full_rounds.is_some() {
-                return Err(de::Error::duplicate_field("full_rounds"));
-              }
-              full_rounds = Some(map.next_value()?);
-            }
-            Field::HalfFullRounds => {
-              if half_full_rounds.is_some() {
-                return Err(de::Error::duplicate_field("half_full_rounds"));
-              }
-              half_full_rounds = Some(map.next_value()?);
-            }
-            Field::PartialRounds => {
-              if partial_rounds.is_some() {
-                return Err(de::Error::duplicate_field("partial_rounds"));
-              }
-              partial_rounds = Some(map.next_value()?);
-            }
-            Field::HashType => {
-              if hash_type.is_some() {
-                return Err(de::Error::duplicate_field("hash_type"));
-              }
-              hash_type = Some(map.next_value()?);
-            }
-          }
+        #[derive(Deserialize)]
+        #[serde(field_identifier, rename_all = "lowercase")]
+        enum Field {
+            MDS,
+            RC,
+            CRC,
+            PSM,
+            SM,
+            S,
+            FR,
+            PR,
+            HT,
         }
-        let mds_matrices = mds_matrices.ok_or_else(|| de::Error::missing_field("mds_matrices"))?;
-        let round_constants = round_constants.ok_or_else(|| de::Error::missing_field("round_constants"))?;
-        let compressed_round_constants = compressed_round_constants.ok_or_else(|| de::Error::missing_field("compressed_round_constants"))?;
-        let pre_sparse_matrix = pre_sparse_matrix.ok_or_else(|| de::Error::missing_field("pre_sparse_matrix"))?;
-        let sparse_matrixes = sparse_matrixes.ok_or_else(|| de::Error::missing_field("sparse_matrixes"))?;
-        let strength = strength.ok_or_else(|| de::Error::missing_field("strength"))?;
-        let domain_tag = domain_tag.ok_or_else(|| de::Error::missing_field("domain_tag"))?;
-        let full_rounds = full_rounds.ok_or_else(|| de::Error::missing_field("full_rounds"))?;
-        let half_full_rounds = half_full_rounds.ok_or_else(|| de::Error::missing_field("half_full_rounds"))?;
-        let partial_rounds = partial_rounds.ok_or_else(|| de::Error::missing_field("partial_rounds"))?;
-        let hash_type = hash_type.ok_or_else(|| de::Error::missing_field("hash_type"))?;
-        Ok(PoseidonConstants {
-	  mds_matrices,
-	  round_constants,
-	  compressed_round_constants,
-	  pre_sparse_matrix,
-	  sparse_matrixes,
-	  strength,
-	  domain_tag,
-	  full_rounds,
-	  half_full_rounds,
-	  partial_rounds,
-	  hash_type,
-	  _a: PhantomData
-	})
-      }
-    }
 
-      const FIELDS: &'static [&'static str] = &["
+        struct PoseidonConstantsVisitor<F, A>
+        where
+            F: PrimeField,
+            A: Arity<F>,
+        {
+            _f: PhantomData<F>,
+            _a: PhantomData<A>,
+        }
+
+        impl<'de, F, A> Visitor<'de> for PoseidonConstantsVisitor<F, A>
+        where
+            F: PrimeField + Deserialize<'de>,
+            A: Arity<F>,
+        {
+            type Value = PoseidonConstants<F, A>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("struct PoseidonConstants")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<PoseidonConstants<F, A>, V::Error>
+            where
+                V: SeqAccess<'de>,
+            {
+                let mds_matrices = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(0, &self))?;
+                let round_constants = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+                let compressed_round_constants = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(2, &self))?;
+                let pre_sparse_matrix = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(3, &self))?;
+                let sparse_matrixes = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(4, &self))?;
+                let strength = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(5, &self))?;
+                let full_rounds = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(6, &self))?;
+                let partial_rounds = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(7, &self))?;
+                let hash_type: HashType<F, A> = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(8, &self))?;
+
+                Ok(PoseidonConstants {
+                    mds_matrices,
+                    round_constants,
+                    compressed_round_constants,
+                    pre_sparse_matrix,
+                    sparse_matrixes,
+                    strength,
+                    domain_tag: hash_type.domain_tag(),
+                    full_rounds,
+                    half_full_rounds: full_rounds / 2,
+                    partial_rounds,
+                    hash_type,
+                    _a: PhantomData::<A>,
+                })
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<PoseidonConstants<F, A>, V::Error>
+            where
+                V: MapAccess<'de>,
+            {
+                let mut mds_matrices = None;
+                let mut round_constants = None;
+                let mut compressed_round_constants = None;
+                let mut pre_sparse_matrix = None;
+                let mut sparse_matrixes = None;
+                let mut strength = None;
+                let mut full_rounds = None;
+                let mut partial_rounds = None;
+                let mut hash_type = None;
+
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::MDS => {
+                            if mds_matrices.is_some() {
+                                return Err(de::Error::duplicate_field("mds_matrices"));
+                            }
+                            mds_matrices = Some(map.next_value()?);
+                        }
+                        Field::RC => {
+                            if round_constants.is_some() {
+                                return Err(de::Error::duplicate_field("round_constants"));
+                            }
+                            round_constants = Some(map.next_value()?);
+                        }
+                        Field::CRC => {
+                            if compressed_round_constants.is_some() {
+                                return Err(de::Error::duplicate_field(
+                                    "compressed_round_constants",
+                                ));
+                            }
+                            compressed_round_constants = Some(map.next_value()?);
+                        }
+                        Field::PSM => {
+                            if pre_sparse_matrix.is_some() {
+                                return Err(de::Error::duplicate_field("pre_sparse_matrix"));
+                            }
+                            pre_sparse_matrix = Some(map.next_value()?);
+                        }
+                        Field::SM => {
+                            if sparse_matrixes.is_some() {
+                                return Err(de::Error::duplicate_field("sparse_matrixes"));
+                            }
+                            sparse_matrixes = Some(map.next_value()?);
+                        }
+                        Field::S => {
+                            if strength.is_some() {
+                                return Err(de::Error::duplicate_field("strength"));
+                            }
+                            strength = Some(map.next_value()?);
+                        }
+                        Field::FR => {
+                            if full_rounds.is_some() {
+                                return Err(de::Error::duplicate_field("full_rounds"));
+                            }
+                            full_rounds = Some(map.next_value()?);
+                        }
+                        Field::PR => {
+                            if partial_rounds.is_some() {
+                                return Err(de::Error::duplicate_field("partial_rounds"));
+                            }
+                            partial_rounds = Some(map.next_value()?);
+                        }
+                        Field::HT => {
+                            if hash_type.is_some() {
+                                return Err(de::Error::duplicate_field("hash_type"));
+                            }
+                            hash_type = Some(map.next_value()?);
+                        }
+                    }
+                }
+
+                let mds_matrices =
+                    mds_matrices.ok_or_else(|| de::Error::missing_field("mds_matrices"))?;
+                let round_constants =
+                    round_constants.ok_or_else(|| de::Error::missing_field("round_constants"))?;
+                let compressed_round_constants = compressed_round_constants
+                    .ok_or_else(|| de::Error::missing_field("compressed_round_constants"))?;
+                let pre_sparse_matrix = pre_sparse_matrix
+                    .ok_or_else(|| de::Error::missing_field("pre_sparse_matrix"))?;
+                let sparse_matrixes =
+                    sparse_matrixes.ok_or_else(|| de::Error::missing_field("sparse_matrixes"))?;
+                let strength = strength.ok_or_else(|| de::Error::missing_field("strength"))?;
+                let full_rounds =
+                    full_rounds.ok_or_else(|| de::Error::missing_field("full_rounds"))?;
+                let partial_rounds =
+                    partial_rounds.ok_or_else(|| de::Error::missing_field("partial_rounds"))?;
+                let hash_type: HashType<F, A> =
+                    hash_type.ok_or_else(|| de::Error::missing_field("hash_type"))?;
+                Ok(PoseidonConstants {
+                    mds_matrices,
+                    round_constants,
+                    compressed_round_constants,
+                    pre_sparse_matrix,
+                    sparse_matrixes,
+                    strength,
+                    domain_tag: hash_type.domain_tag(),
+                    full_rounds,
+                    half_full_rounds: full_rounds / 2,
+                    partial_rounds,
+                    hash_type,
+                    _a: PhantomData::<A>,
+                })
+            }
+        }
+
+        const FIELDS: &'static [&'static str] = &["
 	  mds_matrices,
 	  round_constants,
 	  compressed_round_constants,
 	  pre_sparse_matrix,
 	  sparse_matrixes,
 	  strength,
-	  domain_tag,
 	  full_rounds,
-	  half_full_rounds,
 	  partial_rounds,
 	  hash_type,
 "];
-    deserializer.deserialize_struct("PoseidonConstants", FIELDS, PoseidonConstantsVisitor { _f: PhantomData, _a: PhantomData })
-
-  }
+        deserializer.deserialize_struct(
+            "PoseidonConstants",
+            FIELDS,
+            PoseidonConstantsVisitor {
+                _f: PhantomData,
+                _a: PhantomData,
+            },
+        )
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  use super::*;
-  use typenum::U1;
+    use super::*;
+    use typenum::U1;
 
-  #[test]
-  fn serde_poseidon_constants() {
-    let mystruct = PoseidonConstants::<S1, U1>::new();
+    #[test]
+    fn serde_roundtrip_constants() {
+        let constants = PoseidonConstants::<S1, U1>::new();
 
-    assert_eq!(mystruct, serde_json::from_slice(&serde_json::to_vec(&mystruct).unwrap()).unwrap());
-  } 
+        assert_eq!(
+            constants,
+            serde_json::from_slice(&serde_json::to_vec(&constants).unwrap()).unwrap()
+        );
+    }
 }

--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -30,8 +30,8 @@ where
         state.serialize_field("psm", &self.pre_sparse_matrix)?;
         state.serialize_field("sm", &self.sparse_matrixes)?;
         state.serialize_field("s", &self.strength)?;
-        state.serialize_field("fr", &self.full_rounds)?;
-        state.serialize_field("pr", &self.partial_rounds)?;
+        state.serialize_field("rf", &self.full_rounds)?;
+        state.serialize_field("rp", &self.partial_rounds)?;
         state.serialize_field("ht", &self.hash_type)?;
         state.end()
     }
@@ -49,15 +49,15 @@ where
         #[derive(Deserialize)]
         #[serde(field_identifier, rename_all = "lowercase")]
         enum Field {
-            MDS,
-            RC,
-            CRC,
-            PSM,
-            SM,
+            Mds,
+            Rc,
+            Crc,
+            Psm,
+            Sm,
             S,
-            FR,
-            PR,
-            HT,
+            Rf,
+            Rp,
+            Ht,
         }
 
         struct PoseidonConstantsVisitor<F, A>
@@ -144,19 +144,19 @@ where
 
                 while let Some(key) = map.next_key()? {
                     match key {
-                        Field::MDS => {
+                        Field::Mds => {
                             if mds_matrices.is_some() {
                                 return Err(de::Error::duplicate_field("mds_matrices"));
                             }
                             mds_matrices = Some(map.next_value()?);
                         }
-                        Field::RC => {
+                        Field::Rc => {
                             if round_constants.is_some() {
                                 return Err(de::Error::duplicate_field("round_constants"));
                             }
                             round_constants = Some(map.next_value()?);
                         }
-                        Field::CRC => {
+                        Field::Crc => {
                             if compressed_round_constants.is_some() {
                                 return Err(de::Error::duplicate_field(
                                     "compressed_round_constants",
@@ -164,13 +164,13 @@ where
                             }
                             compressed_round_constants = Some(map.next_value()?);
                         }
-                        Field::PSM => {
+                        Field::Psm => {
                             if pre_sparse_matrix.is_some() {
                                 return Err(de::Error::duplicate_field("pre_sparse_matrix"));
                             }
                             pre_sparse_matrix = Some(map.next_value()?);
                         }
-                        Field::SM => {
+                        Field::Sm => {
                             if sparse_matrixes.is_some() {
                                 return Err(de::Error::duplicate_field("sparse_matrixes"));
                             }
@@ -182,19 +182,19 @@ where
                             }
                             strength = Some(map.next_value()?);
                         }
-                        Field::FR => {
+                        Field::Rf => {
                             if full_rounds.is_some() {
                                 return Err(de::Error::duplicate_field("full_rounds"));
                             }
                             full_rounds = Some(map.next_value()?);
                         }
-                        Field::PR => {
+                        Field::Rp => {
                             if partial_rounds.is_some() {
                                 return Err(de::Error::duplicate_field("partial_rounds"));
                             }
                             partial_rounds = Some(map.next_value()?);
                         }
-                        Field::HT => {
+                        Field::Ht => {
                             if hash_type.is_some() {
                                 return Err(de::Error::duplicate_field("hash_type"));
                             }
@@ -237,7 +237,7 @@ where
             }
         }
 
-        const FIELDS: &'static [&'static str] = &["
+        const FIELDS: &[&str] = &["
 	  mds_matrices,
 	  round_constants,
 	  compressed_round_constants,

--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -1,0 +1,270 @@
+use std::fmt;
+use serde::{
+  ser::{Serializer, SerializeStruct},
+  Serialize,
+  Deserialize,
+  de::{self, Deserializer, Visitor, SeqAccess, MapAccess},
+};
+use generic_array::typenum;
+use typenum::Unsigned;
+use ff::PrimeField;
+use std::marker::PhantomData;
+use pasta_curves::pallas::Scalar as S1;
+
+use crate::Arity;
+use crate::poseidon::PoseidonConstants;
+
+impl<F, A> Serialize for PoseidonConstants<F, A>
+  where
+  F: PrimeField + Serialize,
+  A: Arity<F>,
+{
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut state = serializer.serialize_struct("PoseidonConstants", 11)?;
+    state.serialize_field("mdsmatrices", &self.mds_matrices)?;
+    state.serialize_field("roundconstants", &self.round_constants)?;
+    state.serialize_field("compressedroundconstants", &self.compressed_round_constants)?;
+    state.serialize_field("presparsematrix", &self.pre_sparse_matrix)?;
+    state.serialize_field("sparsematrixes", &self.sparse_matrixes)?;
+    state.serialize_field("strength", &self.strength)?;
+    state.serialize_field("domaintag", &self.domain_tag)?;
+    state.serialize_field("fullrounds", &self.full_rounds)?;
+    state.serialize_field("halffullrounds", &self.half_full_rounds)?;
+    state.serialize_field("partialrounds", &self.partial_rounds)?;
+    state.serialize_field("hashtype", &self.hash_type)?;
+    state.end()
+  }
+}
+
+impl<'de, F, A> Deserialize<'de> for PoseidonConstants<F, A>
+where
+  F: PrimeField + Deserialize<'de>,
+  A: Arity<F>,
+{
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+  where D: Deserializer<'de>,
+  {
+    #[derive(Deserialize)]
+    #[serde(field_identifier, rename_all = "lowercase")]
+    enum Field {
+      MdsMatrices,
+      RoundConstants,
+      CompressedRoundConstants,
+      PreSparseMatrix,
+      SparseMatrixes,
+      Strength,
+      DomainTag,
+      FullRounds,
+      HalfFullRounds,
+      PartialRounds,
+      HashType,
+    }
+
+    struct PoseidonConstantsVisitor<F, A>
+    where
+      F: PrimeField,
+      A: Arity<F>,
+    {
+      _f: PhantomData<F>,
+      _a: PhantomData<A>,
+    }
+
+    impl<'de, F, A> Visitor<'de> for PoseidonConstantsVisitor<F, A>
+    where
+      F: PrimeField + Deserialize<'de>,
+      A: Arity<F>,
+    {
+      type Value = PoseidonConstants<F, A>;
+
+      fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("struct PoseidonConstants")
+      }
+
+      fn visit_seq<V>(self, mut seq: V) -> Result<PoseidonConstants<F, A>, V::Error>
+      where
+        V: SeqAccess<'de>,
+      {
+        let mds_matrices = seq.next_element()?
+          .ok_or_else(|| de::Error::invalid_length(0, &self))?;
+        let round_constants = seq.next_element()?
+          .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+        let compressed_round_constants = seq.next_element()?
+          .ok_or_else(|| de::Error::invalid_length(2, &self))?;
+        let pre_sparse_matrix = seq.next_element()?
+          .ok_or_else(|| de::Error::invalid_length(3, &self))?;
+        let sparse_matrixes = seq.next_element()?
+          .ok_or_else(|| de::Error::invalid_length(3, &self))?;
+        let strength = seq.next_element()?
+          .ok_or_else(|| de::Error::invalid_length(4, &self))?;
+        let domain_tag = seq.next_element()?
+          .ok_or_else(|| de::Error::invalid_length(5, &self))?;
+        let full_rounds = seq.next_element()?
+          .ok_or_else(|| de::Error::invalid_length(6, &self))?;
+        let half_full_rounds = seq.next_element()?
+          .ok_or_else(|| de::Error::invalid_length(7, &self))?;
+        let partial_rounds = seq.next_element()?
+          .ok_or_else(|| de::Error::invalid_length(8, &self))?;
+        let hash_type = seq.next_element()?
+          .ok_or_else(|| de::Error::invalid_length(9, &self))?;
+        Ok(PoseidonConstants {
+	  mds_matrices,
+	  round_constants,
+	  compressed_round_constants,
+	  pre_sparse_matrix,
+	  sparse_matrixes,
+	  strength,
+	  domain_tag,
+	  full_rounds,
+	  half_full_rounds,
+	  partial_rounds,
+	  hash_type,
+	  _a: PhantomData
+	})
+      }
+
+      fn visit_map<V>(self, mut map: V) -> Result<PoseidonConstants<F, A>, V::Error>
+      where
+        V: MapAccess<'de>,
+      {
+	let mut mds_matrices = None;
+	let mut round_constants = None;
+	let mut compressed_round_constants = None;
+	let mut pre_sparse_matrix = None;
+	let mut sparse_matrixes = None;
+	let mut strength = None;
+	let mut domain_tag = None;
+	let mut full_rounds = None;
+	let mut half_full_rounds = None;
+	let mut partial_rounds = None;
+	let mut hash_type = None;
+        while let Some(key) = map.next_key()? {
+          match key {
+            Field::MdsMatrices => {
+              if mds_matrices.is_some() {
+                return Err(de::Error::duplicate_field("mds_matrices"));
+              }
+              mds_matrices = Some(map.next_value()?);
+            }
+            Field::RoundConstants => {
+              if round_constants.is_some() {
+                return Err(de::Error::duplicate_field("round_constants"));
+              }
+              round_constants = Some(map.next_value()?);
+            }
+            Field::CompressedRoundConstants => {
+              if compressed_round_constants.is_some() {
+                return Err(de::Error::duplicate_field("compressed_round_constants"));
+              }
+              compressed_round_constants = Some(map.next_value()?);
+            }
+            Field::PreSparseMatrix => {
+              if pre_sparse_matrix.is_some() {
+                return Err(de::Error::duplicate_field("pre_sparse_matrix"));
+              }
+              pre_sparse_matrix = Some(map.next_value()?);
+            }
+            Field::SparseMatrixes => {
+              if sparse_matrixes.is_some() {
+                return Err(de::Error::duplicate_field("sparse_matrixes"));
+              }
+              sparse_matrixes = Some(map.next_value()?);
+            }
+            Field::Strength => {
+              if strength.is_some() {
+                return Err(de::Error::duplicate_field("strength"));
+              }
+              strength = Some(map.next_value()?);
+            }
+            Field::DomainTag => {
+              if domain_tag.is_some() {
+                return Err(de::Error::duplicate_field("domain_tag"));
+              }
+              domain_tag = Some(map.next_value()?);
+            }
+            Field::FullRounds => {
+              if full_rounds.is_some() {
+                return Err(de::Error::duplicate_field("full_rounds"));
+              }
+              full_rounds = Some(map.next_value()?);
+            }
+            Field::HalfFullRounds => {
+              if half_full_rounds.is_some() {
+                return Err(de::Error::duplicate_field("half_full_rounds"));
+              }
+              half_full_rounds = Some(map.next_value()?);
+            }
+            Field::PartialRounds => {
+              if partial_rounds.is_some() {
+                return Err(de::Error::duplicate_field("partial_rounds"));
+              }
+              partial_rounds = Some(map.next_value()?);
+            }
+            Field::HashType => {
+              if hash_type.is_some() {
+                return Err(de::Error::duplicate_field("hash_type"));
+              }
+              hash_type = Some(map.next_value()?);
+            }
+          }
+        }
+        let mds_matrices = mds_matrices.ok_or_else(|| de::Error::missing_field("mds_matrices"))?;
+        let round_constants = round_constants.ok_or_else(|| de::Error::missing_field("round_constants"))?;
+        let compressed_round_constants = compressed_round_constants.ok_or_else(|| de::Error::missing_field("compressed_round_constants"))?;
+        let pre_sparse_matrix = pre_sparse_matrix.ok_or_else(|| de::Error::missing_field("pre_sparse_matrix"))?;
+        let sparse_matrixes = sparse_matrixes.ok_or_else(|| de::Error::missing_field("sparse_matrixes"))?;
+        let strength = strength.ok_or_else(|| de::Error::missing_field("strength"))?;
+        let domain_tag = domain_tag.ok_or_else(|| de::Error::missing_field("domain_tag"))?;
+        let full_rounds = full_rounds.ok_or_else(|| de::Error::missing_field("full_rounds"))?;
+        let half_full_rounds = half_full_rounds.ok_or_else(|| de::Error::missing_field("half_full_rounds"))?;
+        let partial_rounds = partial_rounds.ok_or_else(|| de::Error::missing_field("partial_rounds"))?;
+        let hash_type = hash_type.ok_or_else(|| de::Error::missing_field("hash_type"))?;
+        Ok(PoseidonConstants {
+	  mds_matrices,
+	  round_constants,
+	  compressed_round_constants,
+	  pre_sparse_matrix,
+	  sparse_matrixes,
+	  strength,
+	  domain_tag,
+	  full_rounds,
+	  half_full_rounds,
+	  partial_rounds,
+	  hash_type,
+	  _a: PhantomData
+	})
+      }
+    }
+
+      const FIELDS: &'static [&'static str] = &["
+	  mds_matrices,
+	  round_constants,
+	  compressed_round_constants,
+	  pre_sparse_matrix,
+	  sparse_matrixes,
+	  strength,
+	  domain_tag,
+	  full_rounds,
+	  half_full_rounds,
+	  partial_rounds,
+	  hash_type,
+"];
+    deserializer.deserialize_struct("PoseidonConstants", FIELDS, PoseidonConstantsVisitor { _f: PhantomData, _a: PhantomData })
+
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use typenum::U1;
+
+  #[test]
+  fn serde_poseidon_constants() {
+    let mystruct = PoseidonConstants::<S1, U1>::new();
+
+    assert_eq!(mystruct, serde_json::from_slice(&serde_json::to_vec(&mystruct).unwrap()).unwrap());
+  } 
+}


### PR DESCRIPTION
Manual serialization is needed for `PoseidonConstants` due to `Arity`'s `typenum` parameter, which doesn't have an easy serde implementation but is only used in `CType`. Serialization is thus skipped for `Arity` and easily calculable `PoseidonConstants` fields like `domain_tag` and `half_full_rounds`.

Once const generics are workable and https://github.com/filecoin-project/neptune/pull/125 is merged, we could instead derive serde automatically.