### PR TITLE
Enforce zero

### DIFF
--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -390,7 +390,7 @@ where
     elements.extend(preimage.into_iter().map(Elt::Allocated));
 
     if let HashType::ConstantLength(length) = constants.hash_type {
-        assert!(length == arity, "length must be equal to arity");
+        assert!(length == arity, "Length must be equal to arity since no padding is provided. Check circuit2.rs for optimized and complete imlpementation");
     }
 
     let mut p = PoseidonCircuit::new(elements, constants);

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -390,7 +390,7 @@ where
     elements.extend(preimage.into_iter().map(Elt::Allocated));
 
     if let HashType::ConstantLength(length) = constants.hash_type {
-        assert!(length == arity, "Length must be equal to arity since no padding is provided. Check circuit2.rs for optimized and complete imlpementation");
+        assert!(length == arity, "Length must be equal to arity since no padding is provided. Check circuit2.rs for optimized and complete implementation");
     }
 
     let mut p = PoseidonCircuit::new(elements, constants);

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -374,7 +374,7 @@ where
 
 /// Create legacy circuit for Poseidon hash. If possible, prefer the equivalent 'optimal' alternatives.
 pub fn poseidon_hash<CS, Scalar, A>(
-    mut cs: CS,
+    cs: CS,
     preimage: Vec<AllocatedNum<Scalar>>,
     constants: &PoseidonConstants<Scalar, A>,
 ) -> Result<AllocatedNum<Scalar>, SynthesisError>
@@ -390,15 +390,7 @@ where
     elements.extend(preimage.into_iter().map(Elt::Allocated));
 
     if let HashType::ConstantLength(length) = constants.hash_type {
-        assert!(length <= arity, "illegal length: constants are malformed");
-        // Add zero-padding.
-        for i in 0..(arity - length) {
-            let allocated = AllocatedNum::alloc(cs.namespace(|| format!("padding {}", i)), || {
-                Ok(Scalar::zero())
-            })?;
-            let elt = Elt::Allocated(allocated);
-            elements.push(elt);
-        }
+        assert!(length == arity, "length must be equal to arity");
     }
 
     let mut p = PoseidonCircuit::new(elements, constants);
@@ -646,8 +638,6 @@ mod tests {
         test_poseidon_hash_aux::<typenum::U16>(Strength::Strengthened, 821, false);
         test_poseidon_hash_aux::<typenum::U24>(Strength::Strengthened, 1069, false);
         test_poseidon_hash_aux::<typenum::U36>(Strength::Strengthened, 1445, false);
-
-        test_poseidon_hash_aux::<typenum::U15>(Strength::Standard, 730, true);
     }
 
     fn test_poseidon_hash_aux<A>(

--- a/src/circuit2.rs
+++ b/src/circuit2.rs
@@ -449,26 +449,6 @@ pub fn enforce_zero<CS: ConstraintSystem<F>, F: PrimeField>(
     Ok(())
 }
 
-#[test]
-fn test_num_zero() {
-    use blstrs::Scalar as Fr;
-    {
-        let mut cs = TestConstraintSystem::<Fr>::new();
-
-        let n = AllocatedNum::alloc(&mut cs, || Ok(Fr::from(3u64))).unwrap();
-        enforce_zero(&mut cs, &n).unwrap();
-
-        assert!(!cs.is_satisfied());
-    }
-    {
-        let mut cs = TestConstraintSystem::<Fr>::new();
-
-        let n = AllocatedNum::alloc(&mut cs, || Ok(Fr::zero())).unwrap();
-        enforce_zero(&mut cs, &n).unwrap();
-        assert!(cs.is_satisfied());
-    }
-}
-
 /// Create circuit for Poseidon hash, returning an unallocated `Num` at the cost of one constraint.
 pub fn poseidon_hash_allocated<CS, Scalar, A>(
     mut cs: CS,
@@ -1032,4 +1012,25 @@ mod tests {
         assert!(res.is_num());
         assert_eq!(fr(59), res.val().unwrap());
     }
+
+    #[test]
+    fn test_num_zero() {
+        use blstrs::Scalar as Fr;
+        {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let n = AllocatedNum::alloc(&mut cs, || Ok(Fr::from(3u64))).unwrap();
+            enforce_zero(&mut cs, &n).unwrap();
+
+            assert!(!cs.is_satisfied());
+        }
+        {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let n = AllocatedNum::alloc(&mut cs, || Ok(Fr::zero())).unwrap();
+            enforce_zero(&mut cs, &n).unwrap();
+            assert!(cs.is_satisfied());
+        }
+    }
+
 }

--- a/src/circuit2.rs
+++ b/src/circuit2.rs
@@ -7,10 +7,10 @@ use crate::mds::SparseMatrix;
 use crate::poseidon::{Arity, PoseidonConstants};
 use bellperson::gadgets::boolean::Boolean;
 use bellperson::gadgets::num::{self, AllocatedNum};
+use bellperson::gadgets::test::TestConstraintSystem;
 use bellperson::{ConstraintSystem, LinearCombination, SynthesisError};
 use ff::{Field, PrimeField};
 use std::marker::PhantomData;
-use bellperson::gadgets::test::TestConstraintSystem;
 
 /// Similar to `num::Num`, we use `Elt` to accumulate both values and linear combinations, then eventually
 /// extract into a `num::AllocatedNum`, enforcing that the linear combination corresponds to the result.
@@ -438,7 +438,6 @@ pub fn enforce_zero<CS: ConstraintSystem<F>, F: PrimeField>(
     mut cs: CS,
     a: &AllocatedNum<F>,
 ) -> Result<(), SynthesisError> {
-
     // Constrain a * 1 = 0
     cs.enforce(
         || "enforce zero constraint",
@@ -470,9 +469,6 @@ fn test_num_zero() {
     }
 }
 
-
-
-
 /// Create circuit for Poseidon hash, returning an unallocated `Num` at the cost of one constraint.
 pub fn poseidon_hash_allocated<CS, Scalar, A>(
     mut cs: CS,
@@ -497,7 +493,10 @@ where
             let allocated = AllocatedNum::alloc(cs.namespace(|| format!("padding {}", i)), || {
                 Ok(Scalar::zero())
             })?;
-            enforce_zero(cs.namespace(|| format!("assert zero padding {}", i)), &allocated)?;
+            enforce_zero(
+                cs.namespace(|| format!("assert zero padding {}", i)),
+                &allocated,
+            )?;
             let elt = Elt::Allocated(allocated);
             elements.push(elt);
         }
@@ -831,7 +830,8 @@ mod tests {
 
                 let zero_padding_cost = constants.arity() - data.len();
 
-                let expected_constraints_calculated = expected_constraints_calculated + 1 + zero_padding_cost;
+                let expected_constraints_calculated =
+                    expected_constraints_calculated + 1 + zero_padding_cost;
                 let expected_constraints = expected_constraints + 1 + zero_padding_cost;
 
                 assert!(cs.is_satisfied(), "constraints not satisfied");

--- a/src/circuit2.rs
+++ b/src/circuit2.rs
@@ -1032,5 +1032,4 @@ mod tests {
             assert!(cs.is_satisfied());
         }
     }
-
 }

--- a/src/circuit2.rs
+++ b/src/circuit2.rs
@@ -783,8 +783,7 @@ mod tests {
                 let mut p = Poseidon::<Fr, A>::new_with_preimage(&fr_data, &constants);
                 let expected: Fr = p.hash_in_mode(HashMode::Correct);
 
-                let expected_constraints_calculated =
-                    expected_constraints_calculated + 1;
+                let expected_constraints_calculated = expected_constraints_calculated + 1;
                 let expected_constraints = expected_constraints + 1;
 
                 assert!(cs.is_satisfied(), "constraints not satisfied");


### PR DESCRIPTION
This PR changes the following:
* instead padding with a new allocated variable, we are using the "internal zero" of the linear combination, therefore simply a scalar coefficient. 